### PR TITLE
Document V2 deployment checks and playtest docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,14 @@ This file is the source of truth for humans and agents working in this repo.
 - Run targeted tests for `game-core` whenever rules or scoring logic changes.
 - Prefer deterministic tests with fixed seeds.
 - If you cannot run installs or tests because of environment restrictions, say so explicitly.
+- After merging to `develop`, verify staging deployment health with platform CLIs:
+  - check `Vercel` preview / `develop`
+  - check `Railway` `api-develop`
+  - check staging `/health`
+- After merging to `main`, verify production deployment health with platform CLIs:
+  - check `Vercel` production
+  - check `Railway` `api`
+  - check production `/health`
 
 ## 7. Safety
 - Do not copy official art, rulebook text, logos, or trademarks from Ticket to Ride.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ docs/
     tech-spec.md
     design-system.md
     v2/
+      README.md
       v2-mvp-architecture.md
       v2-multiplayer-flow.md
       v2-deployment.md
@@ -120,6 +121,7 @@ docs/
     v1-status.md
   playtests/
     v0.4/
+    mvp2/
   assets/
 scripts/
   config/        snapshot switching, preview, export, release tooling
@@ -138,6 +140,7 @@ scripts/
 - [Docs Index](docs/README.md)
 - [Product Requirements](docs/product/prd.md)
 - [Tech Spec](docs/product/tech-spec.md)
+- [V2 Docs Index](docs/product/v2/README.md)
 - [V2 MVP Architecture](docs/product/v2/v2-mvp-architecture.md)
 - [V2 Multiplayer Flow](docs/product/v2/v2-multiplayer-flow.md)
 - [V2 Deployment](docs/product/v2/v2-deployment.md)
@@ -148,6 +151,7 @@ scripts/
 - [Config Snapshot Guide](docs/config/config-snapshot-guide.md)
 - [Design System](docs/product/design-system.md)
 - [Map And Balance Notes](docs/map/map-balance-notes.md)
+- [MVP2 Staging Smoke Checklist](docs/playtests/mvp2/staging-smoke-checklist.md)
 - [Agent Operating Guide](AGENTS.md)
 
 ## Current Product Status

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This folder now separates long-lived product docs from versioned playtest artifa
 - [PRD](/Users/djfan/Workspace/HudsonHustle/docs/product/prd.md)
 - [Tech Spec](/Users/djfan/Workspace/HudsonHustle/docs/product/tech-spec.md)
 - [Design System](/Users/djfan/Workspace/HudsonHustle/docs/product/design-system.md)
+- [V2 Docs Index](/Users/djfan/Workspace/HudsonHustle/docs/product/v2/README.md)
 - V2
   - [V2 MVP Architecture](/Users/djfan/Workspace/HudsonHustle/docs/product/v2/v2-mvp-architecture.md)
   - [V2 Multiplayer Flow](/Users/djfan/Workspace/HudsonHustle/docs/product/v2/v2-multiplayer-flow.md)
@@ -45,6 +46,10 @@ This folder now separates long-lived product docs from versioned playtest artifa
 - Raw logs:
   - [Seed 42](/Users/djfan/Workspace/HudsonHustle/docs/playtests/v0.4/raw/seed-42-raw.md)
   - [Seed 1337](/Users/djfan/Workspace/HudsonHustle/docs/playtests/v0.4/raw/seed-1337-raw.md)
+
+### MVP2
+- [MVP2 Playtests Index](/Users/djfan/Workspace/HudsonHustle/docs/playtests/mvp2/README.md)
+- [Staging Smoke Checklist](/Users/djfan/Workspace/HudsonHustle/docs/playtests/mvp2/staging-smoke-checklist.md)
 
 ## Assets
 - `docs/assets/` stores README and docs illustration assets.

--- a/docs/playtests/mvp2/README.md
+++ b/docs/playtests/mvp2/README.md
@@ -1,0 +1,15 @@
+# MVP2 Playtests
+
+This folder is for multiplayer validation artifacts for `v2.0 / MVP2`.
+
+## Current Focus
+- deployed staging smoke passes
+- reconnect and timer behavior
+- private/public state separation
+- multi-device validation on `develop`
+
+## Suggested Contents
+- staging smoke checklist
+- staging run notes
+- remote device test results
+- post-merge validation notes for `develop`

--- a/docs/playtests/mvp2/staging-smoke-checklist.md
+++ b/docs/playtests/mvp2/staging-smoke-checklist.md
@@ -1,0 +1,37 @@
+# MVP2 Staging Smoke Checklist
+
+Run this on the deployed `develop` environment after meaningful multiplayer merges.
+
+## Backend
+- staging backend `/health` returns `200`
+- released configs list is correct
+
+## Frontend
+- staging frontend loads without a blank screen
+- create/join UI is visible
+
+## Room Lifecycle
+- create room succeeds
+- second client can join
+- ready/start succeeds
+
+## Multiplayer Flow
+- each seat only sees its own hand and tickets
+- public board state matches on both clients
+- drawing two cards works
+- end turn hands control to the next player
+
+## Recovery
+- refresh reconnects to the same seat
+- invalid credentials show a real error state
+- lobby connected badge tracks websocket presence correctly
+
+## Timer
+- untimed room stays untimed
+- timed room shows the configured timeout
+- timer countdown appears active during play
+- timeout does not deadlock the room
+
+## Maps
+- `v0.3-atlantic-hoboken` can start
+- `v0.4-flushing-newark-airport` can start

--- a/docs/product/v2/README.md
+++ b/docs/product/v2/README.md
@@ -1,0 +1,13 @@
+# V2 Docs
+
+This folder groups the multiplayer-specific product and engineering docs for `v2`.
+
+## Files
+- [V2 MVP Architecture](/Users/djfan/Workspace/HudsonHustle/docs/product/v2/v2-mvp-architecture.md)
+- [V2 Multiplayer Flow](/Users/djfan/Workspace/HudsonHustle/docs/product/v2/v2-multiplayer-flow.md)
+- [V2 Deployment](/Users/djfan/Workspace/HudsonHustle/docs/product/v2/v2-deployment.md)
+
+## How To Use These
+- Start with [V2 MVP Architecture](/Users/djfan/Workspace/HudsonHustle/docs/product/v2/v2-mvp-architecture.md) for scope and system boundaries.
+- Use [V2 Multiplayer Flow](/Users/djfan/Workspace/HudsonHustle/docs/product/v2/v2-multiplayer-flow.md) for room UX, reconnect, and player-facing session flow.
+- Use [V2 Deployment](/Users/djfan/Workspace/HudsonHustle/docs/product/v2/v2-deployment.md) for `Vercel` / `Railway` setup and branch-to-environment behavior.

--- a/docs/product/v2/v2-deployment.md
+++ b/docs/product/v2/v2-deployment.md
@@ -29,6 +29,23 @@ Recommended promotion path:
 4. merge `develop` into `main`
 5. let production deploy from `main`
 
+## Post-Merge Verification
+These checks should run by default after merges, not only when someone remembers to ask.
+
+### After Merge To `develop`
+Use platform CLIs to verify the staging path:
+- check `Vercel` preview deployment status for `develop`
+- check `Railway` deployment status for `api-develop`
+- check staging backend health:
+  - `curl https://api-develop-develop.up.railway.app/health`
+
+### After Merge To `main`
+Use platform CLIs to verify the production path:
+- check `Vercel` production deployment status
+- check `Railway` deployment status for `api`
+- check production backend health:
+  - `curl https://api-production-226b.up.railway.app/health`
+
 ## GitHub Actions
 This repo keeps GitHub Actions for CI only:
 


### PR DESCRIPTION
## Summary
- add default post-merge verification rules for develop and main
- add V2 docs index and MVP2 playtests docs index
- add MVP2 staging smoke checklist
- update docs indexes and deployment guidance to reflect the new structure

## Validation
- docs-only change
