### PR TITLE
Fix staging room creation snapshot persistence

### DIFF
--- a/apps/server/src/persistence/postgres-room-repository.ts
+++ b/apps/server/src/persistence/postgres-room-repository.ts
@@ -126,22 +126,26 @@ export class PostgresRoomRepository implements RoomRepository {
       );
     }
 
-    await this.db
-      .insert(gameSnapshotsTable)
-      .values({
-        roomCode: record.roomCode,
-        snapshotVersion: record.snapshotVersion,
-        snapshot: record.game,
-        updatedAt
-      })
-      .onConflictDoUpdate({
-        target: gameSnapshotsTable.roomCode,
-        set: {
+    if (record.game) {
+      await this.db
+        .insert(gameSnapshotsTable)
+        .values({
+          roomCode: record.roomCode,
           snapshotVersion: record.snapshotVersion,
           snapshot: record.game,
           updatedAt
-        }
-      });
+        })
+        .onConflictDoUpdate({
+          target: gameSnapshotsTable.roomCode,
+          set: {
+            snapshotVersion: record.snapshotVersion,
+            snapshot: record.game,
+            updatedAt
+          }
+        });
+    } else {
+      await this.db.delete(gameSnapshotsTable).where(eq(gameSnapshotsTable.roomCode, record.roomCode));
+    }
 
     await this.db.insert(gameEventsTable).values({
       roomCode: record.roomCode,


### PR DESCRIPTION
## Summary
- stop writing a null lobby game into game_snapshots
- only persist snapshots after a game state exists
- delete any stale snapshot row when a room has no game yet

## Why
- Railway staging develop was returning 500 on POST /rooms
- root cause was game_snapshots.snapshot being NOT NULL while lobby rooms save with game = null

## Validation
- pnpm --filter @hudson-hustle/server test
- pnpm build