### PR TITLE
Allow Socket.IO transport fallback on staging

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -213,9 +213,7 @@ export default function App(): JSX.Element {
       return;
     }
 
-    const socket = io(wsUrl, {
-      transports: ["websocket"]
-    });
+    const socket = io(wsUrl);
     socketRef.current = socket;
 
     socket.on("connect", () => {


### PR DESCRIPTION
## Summary
- stop forcing websocket-only Socket.IO transport in the web client
- let the client negotiate default transports so staging can connect through proxies

## Why
- develop staging browser smoke showed HTTP room lifecycle working but realtime lobby seats stayed Offline
- the likely issue is websocket-only transport being too strict for the current staging proxy path

## Validation
- pnpm test
- pnpm build