### PR TITLE
Fix staging socket handshake and lobby gating

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -16,22 +16,45 @@ import { PostgresRoomRepository } from "./persistence/postgres-room-repository.j
 import type { RoomRepository } from "./persistence/types.js";
 import { RoomService, RoomServiceError } from "./room-service.js";
 
+interface OriginRules {
+  exactOrigins: string[];
+  wildcardOrigins: RegExp[];
+}
+
+function buildOriginRules(configuredOrigins: string[]): OriginRules {
+  return {
+    exactOrigins: configuredOrigins.filter((origin) => !origin.includes("*")),
+    wildcardOrigins: configuredOrigins
+      .filter((origin) => origin.includes("*"))
+      .map((pattern) => new RegExp(`^${pattern.split("*").map(escapeRegexForPattern).join(".*")}$`))
+  };
+}
+
+function isOriginAllowed(rules: OriginRules, origin: string | undefined) {
+  if (!origin) {
+    return true;
+  }
+
+  return rules.exactOrigins.includes(origin) || rules.wildcardOrigins.some((pattern) => pattern.test(origin));
+}
+
 export function createCorsOriginMatcher(configuredOrigins: string[]) {
-  const exactOrigins = configuredOrigins.filter((origin) => !origin.includes("*"));
-  const wildcardOrigins = configuredOrigins
-    .filter((origin) => origin.includes("*"))
-    .map((pattern) => new RegExp(`^${pattern.split("*").map(escapeRegexForPattern).join(".*")}$`));
+  const rules = buildOriginRules(configuredOrigins);
 
   if (configuredOrigins.length === 0) {
     return true;
   }
 
   return async (origin: string | undefined) => {
-    if (!origin) {
-      return true;
-    }
+    return isOriginAllowed(rules, origin) ? origin ?? true : false;
+  };
+}
 
-    return exactOrigins.includes(origin) || wildcardOrigins.some((pattern) => pattern.test(origin)) ? origin : false;
+export function createSocketIoCorsOriginMatcher(configuredOrigins: string[]) {
+  const rules = buildOriginRules(configuredOrigins);
+
+  return (origin: string | undefined, callback: (error: Error | null, allow?: boolean) => void) => {
+    callback(null, configuredOrigins.length === 0 ? true : isOriginAllowed(rules, origin));
   };
 }
 
@@ -47,6 +70,7 @@ export async function createServerApp() {
     .map((origin) => origin.trim())
     .filter(Boolean);
   const corsOriginMatcher = createCorsOriginMatcher(corsOrigins);
+  const socketIoCorsOriginMatcher = createSocketIoCorsOriginMatcher(corsOrigins);
 
   await app.register(cors, {
     origin: corsOriginMatcher,
@@ -141,9 +165,25 @@ export async function createServerApp() {
   await app.ready();
   io = new SocketIOServer<ClientToServerEvents, ServerToClientEvents>(app.server, {
     cors: {
-      origin: corsOriginMatcher,
+      origin: socketIoCorsOriginMatcher,
       credentials: true
     }
+  });
+
+  io.engine.on("connection_error", (error) => {
+    app.log.warn(
+      {
+        code: error.code,
+        message: error.message,
+        context: error.context,
+        req: {
+          url: error.req?.url,
+          origin: error.req?.headers.origin,
+          host: error.req?.headers.host
+        }
+      },
+      "Engine.IO connection error"
+    );
   });
 
   io.on("connection", (socket) => {

--- a/apps/server/tests/cors-origin.test.ts
+++ b/apps/server/tests/cors-origin.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createCorsOriginMatcher } from "../src/app.js";
+import { createCorsOriginMatcher, createSocketIoCorsOriginMatcher } from "../src/app.js";
 
 describe("createCorsOriginMatcher", () => {
   it("allows exact local origins and wildcard vercel origins", async () => {
@@ -11,6 +11,22 @@ describe("createCorsOriginMatcher", () => {
 
     expect(allowPreview).toBe(true);
     expect(allowLocal).toBe(true);
+    expect(blockOther).toBe(false);
+  });
+});
+
+describe("createSocketIoCorsOriginMatcher", () => {
+  it("allows exact local origins and wildcard vercel origins via callback", async () => {
+    const matcher = createSocketIoCorsOriginMatcher(["https://*.vercel.app", "http://127.0.0.1:5173"]);
+
+    const allowPreview = await resolveOriginCheck(matcher, "https://hudson-hustle-git-develop-djfan1s-projects.vercel.app");
+    const allowLocal = await resolveOriginCheck(matcher, "http://127.0.0.1:5173");
+    const allowNoOrigin = await resolveOriginCheck(matcher, undefined);
+    const blockOther = await resolveOriginCheck(matcher, "https://example.com");
+
+    expect(allowPreview).toBe(true);
+    expect(allowLocal).toBe(true);
+    expect(allowNoOrigin).toBe(true);
     expect(blockOther).toBe(false);
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -40,6 +40,7 @@ import { TransitCard } from "./components/TransitCard";
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8787";
 const wsUrl = import.meta.env.VITE_WS_URL ?? apiBaseUrl;
 const sessionKey = "hudson-hustle-multiplayer-session-v2";
+type RealtimeStatus = "idle" | "connecting" | "subscribed" | "failed";
 
 interface SessionCredentials {
   roomCode: string;
@@ -158,6 +159,7 @@ export default function App(): JSX.Element {
   const [error, setError] = useState<string | null>(null);
   const [timer, setTimer] = useState<TimerUpdate | null>(null);
   const [timerNow, setTimerNow] = useState(() => Date.now());
+  const [realtimeStatus, setRealtimeStatus] = useState<RealtimeStatus>("idle");
   const [selectedRouteId, setSelectedRouteId] = useState<string | null>(null);
   const [selectedCityId, setSelectedCityId] = useState<string | null>(null);
   const [selectedTicketIds, setSelectedTicketIds] = useState<string[]>([]);
@@ -210,17 +212,37 @@ export default function App(): JSX.Element {
     if (!credentials) {
       socketRef.current?.disconnect();
       socketRef.current = null;
+      setRealtimeStatus("idle");
       return;
     }
 
+    setRealtimeStatus("connecting");
     const socket = io(wsUrl);
     socketRef.current = socket;
+    let handshakeResolved = false;
+    const handshakeTimeout = window.setTimeout(() => {
+      if (handshakeResolved) {
+        return;
+      }
+      awaitingSocketHandshakeRef.current = false;
+      setRealtimeStatus("failed");
+      setError("Realtime connection timed out before the room subscription was confirmed.");
+      setReconnectState("reconnect-failed");
+      socket.disconnect();
+    }, 8000);
+
+    const resolveHandshake = () => {
+      handshakeResolved = true;
+      window.clearTimeout(handshakeTimeout);
+    };
 
     socket.on("connect", () => {
       socket.emit("room:subscribe", credentials);
     });
 
     socket.on("room:update", (room) => {
+      resolveHandshake();
+      setRealtimeStatus("subscribed");
       setSnapshot((current) => (current ? { ...current, room } : { room, game: null, privateState: null }));
     });
 
@@ -233,7 +255,9 @@ export default function App(): JSX.Element {
     });
 
     socket.on("game:reconnected", (nextSnapshot) => {
+      resolveHandshake();
       awaitingSocketHandshakeRef.current = false;
+      setRealtimeStatus("subscribed");
       setSnapshot(nextSnapshot);
       setReconnectState("reconnected");
     });
@@ -243,6 +267,8 @@ export default function App(): JSX.Element {
     });
 
     socket.on("game:error", (payload) => {
+      resolveHandshake();
+      setRealtimeStatus("failed");
       if (awaitingSocketHandshakeRef.current) {
         awaitingSocketHandshakeRef.current = false;
         setReconnectState("reconnect-failed");
@@ -251,25 +277,37 @@ export default function App(): JSX.Element {
     });
 
     socket.on("connect_error", (connectError) => {
+      resolveHandshake();
       awaitingSocketHandshakeRef.current = false;
+      setRealtimeStatus("failed");
       setError(connectError.message || "Could not connect to the room.");
       setReconnectState("reconnect-failed");
     });
 
     socket.on("disconnect", (reason) => {
+      resolveHandshake();
       awaitingSocketHandshakeRef.current = false;
       if (reason === "io client disconnect") {
         return;
       }
+      setRealtimeStatus("failed");
       setError("Connection lost. Reconnect using your saved session details.");
       setReconnectState("reconnect-failed");
     });
 
     return () => {
+      resolveHandshake();
       socket.disconnect();
       socketRef.current = null;
     };
   }, [credentials]);
+
+  const realtimeMessage =
+    realtimeStatus === "connecting"
+      ? "Realtime connection is still being established. Ready and start stay disabled until the live room link is confirmed."
+      : realtimeStatus === "failed"
+        ? "Realtime connection failed. Seat presence and ready/start controls are disabled until the live room link recovers."
+        : null;
 
   useEffect(() => {
     if (!timer?.deadlineAt) {
@@ -551,6 +589,8 @@ export default function App(): JSX.Element {
         onReadyChange={sendReady}
         onStart={() => void startRoom()}
         timer={timer}
+        realtimeReady={realtimeStatus === "subscribed"}
+        realtimeMessage={realtimeMessage}
       />
     );
   }

--- a/apps/web/src/components/LobbyScreen.tsx
+++ b/apps/web/src/components/LobbyScreen.tsx
@@ -8,11 +8,22 @@ interface LobbyScreenProps {
   onReadyChange: (ready: boolean) => void;
   onStart: () => void;
   timer: TimerUpdate | null;
+  realtimeReady: boolean;
+  realtimeMessage: string | null;
 }
 
-export function LobbyScreen({ room, localSeatId, playerSecret, onReadyChange, onStart, timer }: LobbyScreenProps): JSX.Element {
+export function LobbyScreen({
+  room,
+  localSeatId,
+  playerSecret,
+  onReadyChange,
+  onStart,
+  timer,
+  realtimeReady,
+  realtimeMessage
+}: LobbyScreenProps): JSX.Element {
   const localSeat = room.seats.find((seat) => seat.seatId === localSeatId);
-  const canStart = localSeat?.isHost && room.seats.every((seat) => seat.playerName) && room.seats.every((seat) => seat.ready);
+  const canStart = realtimeReady && localSeat?.isHost && room.seats.every((seat) => seat.playerName) && room.seats.every((seat) => seat.ready);
   const joinedCount = room.seats.filter((seat) => seat.playerName).length;
   const readyCount = room.seats.filter((seat) => seat.ready).length;
   const lobbyTone = canStart ? "ready" : localSeat?.isHost ? "host" : "waiting";
@@ -37,6 +48,7 @@ export function LobbyScreen({ room, localSeatId, playerSecret, onReadyChange, on
             <p className="lead">
               Share the room code, let everyone claim a seat, and start once the full table is ready.
             </p>
+            {realtimeMessage ? <p className="error-banner">{realtimeMessage}</p> : null}
             <div className={`status-banner status-banner--${lobbyTone}`} data-testid="lobby-status-banner">
               <div>
                 <span className="status-banner__eyebrow">
@@ -100,7 +112,7 @@ export function LobbyScreen({ room, localSeatId, playerSecret, onReadyChange, on
         </div>
 
         <div className="setup-actions">
-          <button className="secondary-button" onClick={() => onReadyChange(!localSeat?.ready)}>
+          <button className="secondary-button" disabled={!realtimeReady} onClick={() => onReadyChange(!localSeat?.ready)}>
             {localSeat?.ready ? "Mark not ready" : "Mark ready"}
           </button>
           {localSeat?.isHost ? (


### PR DESCRIPTION
## Summary

This PR targets the staging realtime blocker that left lobby seats offline on `develop`.

It makes two focused changes:
- split Fastify and Socket.IO origin handling instead of reusing the async Fastify matcher for Socket.IO
- harden the lobby UX so ready/start stay disabled until realtime subscription is actually confirmed

## What changed

- server:
  - added a Socket.IO-specific callback-style CORS origin matcher
  - kept the existing Fastify async matcher for ordinary HTTP routes
  - added Engine.IO connection-error logging for better staging diagnosis
- web:
  - added a subscribe-ack timeout so the lobby does not sit in `connecting` forever
  - kept ready/start disabled until realtime subscription is confirmed
  - surfaces clearer realtime failure copy in the lobby
- tests:
  - added coverage for the Socket.IO origin matcher callback path

## Why

On staging, ordinary HTTP room lifecycle calls were succeeding, but realtime never completed:
- seats stayed `Offline`
- ready/start could not progress
- direct polling requests to `/socket.io/?EIO=4&transport=polling` were hanging

The leading code-level suspect was reusing the Fastify async origin matcher for Socket.IO/Engine.IO, which has a different API shape.

## Validation

- `pnpm test`
- `pnpm build`
