### PR TITLE
Refine V2 docs and engineering manager skill

### DIFF
--- a/.codex/skills/hudson-hustle-engineering-manager/SKILL.md
+++ b/.codex/skills/hudson-hustle-engineering-manager/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: hudson-hustle-engineering-manager
+description: Use when managing Hudson Hustle engineering work across coding, debugging, testing, delivery, subagent orchestration, and promotion through working branches, develop, and main.
+---
+
+# Hudson Hustle Engineering Manager
+
+Use this skill when the task is not only to write code, but to manage the engineering cycle around it:
+- scoping the next slice
+- coordinating subagents
+- debugging across client/server/platform boundaries
+- deciding merge gates
+- verifying deploy health
+- promoting work through `develop` and `main`
+
+## Manager Role
+The main session is the manager.
+
+Manager responsibilities:
+- keep the critical-path implementation local when the next step depends on it
+- use subagents for bounded exploration, review, or parallel verification
+- synthesize findings into ranked hypotheses
+- choose the smallest defensible fix first
+- require validation before promotion
+
+Do not delegate the immediate blocking fix and then wait idly for it.
+
+## When To Use
+- staging-only or production-only bugs
+- ambiguous regressions that could be client, server, or platform
+- deciding whether a branch is ready for `develop` or `main`
+- coordinating code review before merges
+- planning a debug or hardening cycle
+- deciding what to test locally vs. on staging vs. on production
+
+## Use This Instead Of `roadmap-manager` When
+- the task is about delivery, debugging, runtime verification, merge readiness, or deploy health
+- the task requires subagent orchestration or findings-first code review
+- the question is "is this ready to merge or promote?"
+
+Use `roadmap-manager` instead when the task is mainly:
+- milestone planning
+- scope shaping
+- PRD or roadmap updates
+- sequencing future work without immediate runtime investigation
+
+## Default Subagent Split
+For non-trivial debugging, prefer three lanes:
+
+1. `client`
+- inspect browser/UI assumptions
+- look for stale state, missing acks, disabled flows, or rendering drift
+
+2. `server`
+- inspect transport, auth, CORS, persistence, reducers, timers, and API contracts
+
+3. `platform`
+- inspect Vercel, Railway, deploy state, env drift, branch mapping, auth, and proxy behavior
+
+Ask each subagent for:
+- most likely failure point
+- backups or alternative hypotheses
+- fastest discriminating checks
+- concrete file references
+
+## Debug Workflow
+1. Confirm the symptom shape.
+- separate:
+  - HTTP lifecycle
+  - realtime handshake
+  - browser rendering
+  - deploy/platform behavior
+
+2. Narrow the failing layer before changing code.
+- if `/health` works but the app is broken, do not start by rewriting unrelated UI
+- if local works but staging fails, compare env, proxy, and deploy behavior before broad refactors
+
+3. Rank hypotheses.
+- keep one leading hypothesis
+- keep one or two backup explanations
+- say what is proven vs. still suspected
+
+4. Apply the smallest fix first.
+- avoid multi-factor refactors on the first pass
+- keep root-fix changes separate from UX hardening when possible
+
+5. Re-validate in layers.
+- targeted tests
+- build
+- direct backend probes
+- staging/browser smoke
+- only then consider promotion
+
+## Testing Tendencies
+Prefer this order:
+
+1. local deterministic tests
+2. local build
+3. direct backend probes
+- `/health`
+- key API routes
+- handshake endpoints when relevant
+4. deployed staging smoke
+5. production checks after merge
+
+Do not treat `CI green` as equivalent to `staging works`.
+
+For browser-heavy bugs:
+- one small real browser flow is worth more than many assumptions
+- preview auth can block verification even when the app is healthy
+- use share links or equivalent access paths when preview protection is enabled
+
+## UI Hardening Rule
+Small UX guards are allowed during root-cause work when they:
+- do not mask the real failure
+- prevent false-positive interactions
+- leave the failure visible
+
+Good examples:
+- disable actions that require realtime until subscription is confirmed
+- show explicit `connecting` or `failed` states
+
+Bad examples:
+- silently fake success
+- hide presence, desync, or transport failures
+
+## Branch and Delivery Rules
+Use the repo ladder:
+- working branch -> `develop`
+- `develop` -> `main`
+
+### Before Merge To `develop`
+- run a code review pass
+- review docs that are affected by the change
+- run local validation
+- merge only when staging is the correct next test surface
+
+### After Merge To `develop`
+- check `Vercel` preview / `develop`
+- check `Railway` `api-develop`
+- check staging `/health`
+- run or request a staging smoke pass if runtime behavior changed
+
+### Before Merge To `main`
+- run a code review pass
+- review docs that are affected by the change
+- require trusted `develop` validation
+- prefer at least one real browser or remote smoke result
+
+### After Merge To `main`
+- check `Vercel` production
+- check `Railway` `api`
+- check production `/health`
+
+## Code Review Default
+Before every merge, review in findings-first mode:
+- bugs and regressions first
+- residual risks second
+- summary last
+
+If no findings exist, say so explicitly and still mention remaining test gaps.
+
+## Hudson Hustle Heuristics
+- gameplay logic belongs in shared code, not in React components
+- UI changes must not silently change gameplay behavior
+- `Offline` with working HTTP room flow usually points to realtime, not room creation
+- `local works / staging fails` usually means env, proxy, deploy, handshake, or auth
+- use subagents to widen evidence, not to duplicate the same hunch
+
+## Deliverables
+A good manager turn should leave behind:
+- one clear root-cause statement
+- one chosen fix
+- one validation result
+- one explicit recommendation:
+  - not ready
+  - ready for `develop`
+  - ready for `main`
+
+## References
+- For merge readiness and promotion checks, read:
+  - [references/merge-gates.md](references/merge-gates.md)

--- a/.codex/skills/hudson-hustle-engineering-manager/references/merge-gates.md
+++ b/.codex/skills/hudson-hustle-engineering-manager/references/merge-gates.md
@@ -1,0 +1,43 @@
+# Merge Gates
+
+Use this reference when deciding whether a Hudson Hustle branch is ready for `develop` or `main`.
+
+## `develop` Gate
+A branch is usually ready for `develop` when:
+- the intended code change is complete enough to validate on staging
+- local targeted tests pass
+- local build passes
+- a findings-first code review has been done
+- affected docs have been updated or intentionally deferred with a reason
+
+After merge to `develop`, verify:
+- `Vercel` preview / `develop`
+- `Railway` `api-develop`
+- staging `/health`
+
+If the change affects runtime multiplayer behavior, prefer a staging smoke pass before promoting further.
+
+## `main` Gate
+A branch is usually ready for `main` only after:
+- the corresponding `develop` result is trusted
+- staging smoke has passed for the relevant behavior
+- any staging-only regressions are resolved
+- a findings-first code review has been done
+- affected docs are aligned with shipped behavior
+
+After merge to `main`, verify:
+- `Vercel` production
+- `Railway` `api`
+- production `/health`
+
+Prefer at least one real browser or remote multiplayer validation before calling a release stable.
+
+## Docs Review Rule
+Before merge to either `develop` or `main`, review whether the change should update:
+- `docs/product/`
+- `docs/gameplay/`
+- `docs/config/`
+- `docs/playtests/`
+- `docs/planning/`
+
+Not every code change needs docs edits, but every merge should include the check.

--- a/.codex/skills/roadmap-manager/SKILL.md
+++ b/.codex/skills/roadmap-manager/SKILL.md
@@ -14,6 +14,18 @@ Use this skill when the task touches project planning, milestone reshaping, or d
 4. Keep v1 focused on same-laptop play unless the user explicitly changes scope.
 5. When implementation changes behavior, reflect that in `docs/product/prd.md`, `docs/product/tech-spec.md`, and `docs/gameplay/player-guide.md` if needed.
 
+## Use This Instead Of `hudson-hustle-engineering-manager` When
+- the task is primarily milestone planning or scope control
+- the work is mostly about PRD, roadmap, sequencing, or status docs
+- you are shaping future work rather than debugging current runtime behavior
+
+Use `hudson-hustle-engineering-manager` instead when the task is about:
+- delivery readiness
+- debugging
+- testing strategy
+- merge gates
+- deploy verification
+
 ## Hudson Hustle Defaults
 - `V1`: local pass-and-play web app.
 - `V2`: authoritative backend for separate-device multiplayer.

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ packages/*/src/*.d.ts.map
 .local/*
 .vercel
 .railway
+tmp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,9 @@ This file is the source of truth for humans and agents working in this repo.
 - Run targeted tests for `game-core` whenever rules or scoring logic changes.
 - Prefer deterministic tests with fixed seeds.
 - If you cannot run installs or tests because of environment restrictions, say so explicitly.
+- Before any merge into `develop` or `main`, do a code review pass with findings-first reporting.
+- Before any merge into `develop` or `main`, review whether affected docs in `docs/` also need updates.
+- Before promoting a branch, prefer the smallest real browser or staging smoke that can catch environment-only regressions.
 - After merging to `develop`, verify staging deployment health with platform CLIs:
   - check `Vercel` preview / `develop`
   - check `Railway` `api-develop`

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ pnpm --filter @hudson-hustle/web exec playwright install chromium
 - Shared deterministic rules engine in `packages/game-core`
 - Shared map and balance data in `packages/game-data`
 
-Planned for `v2`:
+Used in `v2`:
 - `Node.js`
 - `Fastify`
 - `Socket.IO`
@@ -121,7 +121,7 @@ docs/
     v1-status.md
   playtests/
     v0.4/
-    mvp2/
+    v2.0/
   assets/
 scripts/
   config/        snapshot switching, preview, export, release tooling
@@ -130,6 +130,7 @@ scripts/
   workflows/     CI automation
 .codex/skills/
   roadmap-manager/
+  hudson-hustle-engineering-manager/
   game-balance/
   transit-cartography/
   config-snapshot-manager/
@@ -151,7 +152,7 @@ scripts/
 - [Config Snapshot Guide](docs/config/config-snapshot-guide.md)
 - [Design System](docs/product/design-system.md)
 - [Map And Balance Notes](docs/map/map-balance-notes.md)
-- [MVP2 Staging Smoke Checklist](docs/playtests/mvp2/staging-smoke-checklist.md)
+- [V2.0 Staging Smoke Checklist](docs/playtests/v2.0/staging-smoke-checklist.md)
 - [Agent Operating Guide](AGENTS.md)
 
 ## Current Product Status
@@ -159,7 +160,7 @@ scripts/
 - Same-laptop `v1` is playable and documented.
 - The first playable small-map station set and the first full balance/playtest pass are complete.
 - `v2` multiplayer foundation exists but is not yet complete.
-- The main remaining `v2.0` work is staging validation, browser/E2E hardening, and merge/promotion through `develop`.
+- The main remaining `v2.0` work is promotion to `main`, one more remote multiplayer validation pass, and post-promotion observation.
 
 ## Branch Strategy
 - `main`

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,15 +7,11 @@ This folder now separates long-lived product docs from versioned playtest artifa
 - [Tech Spec](/Users/djfan/Workspace/HudsonHustle/docs/product/tech-spec.md)
 - [Design System](/Users/djfan/Workspace/HudsonHustle/docs/product/design-system.md)
 - [V2 Docs Index](/Users/djfan/Workspace/HudsonHustle/docs/product/v2/README.md)
-- V2
-  - [V2 MVP Architecture](/Users/djfan/Workspace/HudsonHustle/docs/product/v2/v2-mvp-architecture.md)
-  - [V2 Multiplayer Flow](/Users/djfan/Workspace/HudsonHustle/docs/product/v2/v2-multiplayer-flow.md)
-  - [V2 Deployment](/Users/djfan/Workspace/HudsonHustle/docs/product/v2/v2-deployment.md)
 
 ## Gameplay
 - [Player Guide](/Users/djfan/Workspace/HudsonHustle/docs/gameplay/player-guide.md)
 - [Onboarding Script](/Users/djfan/Workspace/HudsonHustle/docs/gameplay/onboarding-script.md)
-- [General Agent-vs-Agent Playtest Notes](/Users/djfan/Workspace/HudsonHustle/docs/gameplay/agent-vs-agent-playtest.md)
+- [Agent-vs-Agent Playtesting Guide](/Users/djfan/Workspace/HudsonHustle/docs/gameplay/agent-vs-agent-playtest.md)
 
 ## Map
 - [Cartography Workflow](/Users/djfan/Workspace/HudsonHustle/docs/map/cartography-workflow.md)
@@ -47,9 +43,9 @@ This folder now separates long-lived product docs from versioned playtest artifa
   - [Seed 42](/Users/djfan/Workspace/HudsonHustle/docs/playtests/v0.4/raw/seed-42-raw.md)
   - [Seed 1337](/Users/djfan/Workspace/HudsonHustle/docs/playtests/v0.4/raw/seed-1337-raw.md)
 
-### MVP2
-- [MVP2 Playtests Index](/Users/djfan/Workspace/HudsonHustle/docs/playtests/mvp2/README.md)
-- [Staging Smoke Checklist](/Users/djfan/Workspace/HudsonHustle/docs/playtests/mvp2/staging-smoke-checklist.md)
+### V2.0
+- [V2.0 Playtests Index](/Users/djfan/Workspace/HudsonHustle/docs/playtests/v2.0/README.md)
+- [Staging Smoke Checklist](/Users/djfan/Workspace/HudsonHustle/docs/playtests/v2.0/staging-smoke-checklist.md)
 
 ## Assets
 - `docs/assets/` stores README and docs illustration assets.

--- a/docs/config/config-snapshot-guide.md
+++ b/docs/config/config-snapshot-guide.md
@@ -63,6 +63,10 @@ That means:
 - map iteration is not trapped inside one giant source file
 
 ## Standard Commands
+Historical note:
+- the example commands below intentionally use older draft ids to show the workflow shape
+- the current released small-map build is `v0.4-flushing-newark-airport`
+
 List available configs:
 
 ```bash

--- a/docs/gameplay/agent-vs-agent-playtest.md
+++ b/docs/gameplay/agent-vs-agent-playtest.md
@@ -1,70 +1,59 @@
-# Agent Vs Agent Playtest
+# Agent Vs Agent Playtesting
 
-This document captures one seeded self-play run on the active `v0.4-next-wave` draft using the `how-to-win-hudson-hustle` strategy skill.
+This document is the evergreen guide for running Hudson Hustle agent self-play.
 
-## Setup
+It is not a historical result log.
+Version-specific seeded runs and balance conclusions should live under `docs/playtests/`.
 
-- Map: `Hudson Hustle Anchor Prototype`
-- Seed: `42`
-- Personas:
-  - `central optimizer`
-  - `outer opportunist`
-- Players:
-  - `Blue`
-  - `Red`
+## Purpose
+- compare strategic personas against the same rules and config
+- surface balance pressure without requiring a full human play group every time
+- generate structured move-by-move reasoning, not just winners and losers
 
-## Result
+## Default Inputs
+- current player-facing rules:
+  - [player-guide.md](/Users/djfan/Workspace/HudsonHustle/docs/gameplay/player-guide.md)
+- current active config:
+  - [current.json](/Users/djfan/Workspace/HudsonHustle/configs/hudson-hustle/current.json)
+- strategy skill:
+  - [how-to-win-hudson-hustle](/Users/djfan/Workspace/HudsonHustle/.codex/skills/how-to-win-hudson-hustle/SKILL.md)
 
-- Final score: `Blue 40`, `Red 14`
-- Winner: `Blue`
-- Game length: `50` turns plus final scoring
+## Recommended Persona Pairings
+- `central optimizer` vs `outer opportunist`
+- `scarcity hawk` vs `ticket maximizer`
+- `tunnel conservative` vs `tempo gambler`
 
-## High-Level Read
+Prefer contrasting styles over two generic rational agents.
 
-- The central plan still won on this map.
-- The outer plan made real progress on Jersey and Brooklyn connectors, but it could not keep pace with the center once the central Manhattan chain started converting tickets into score.
-- Tunnel risk mattered early. `Exchange Pl. -> World Trade` failed once on surcharge, which is a good sign that tunnels are not pure upside.
-- The `Newark Airport -> Hudson Yards` helicopter-style tunnel did not become decisive in this seed.
+## Per-Turn Expectations
+Each agent should:
+- observe current hidden and public state first
+- infer the opponent's visible plan from public information
+- choose one move
+- explain:
+  - why this move is best now
+  - what ticket or trunk it protects
+  - what risk it accepts
 
-## Key Turning Points
+## Logging Standard
+Record:
+- config id
+- seed
+- personas
+- opening tickets
+- key choke claims
+- tunnel/ferry swing moments
+- final scores
+- winner
+- short balance read
 
-1. `Blue` spent the first phase drawing toward a central trunk and quickly converted `Atlantic Terminal -> Jamaica`.
-2. `Red` successfully opened the Jersey side with `Exchange Pl. -> World Trade`, `Battery Park -> Red Hook`, `Hoboken -> Chelsea`, and `Hoboken -> Grove St`.
-3. `Blue` then connected the Brooklyn side and the Manhattan middle with `Williamsburg`, `Chelsea`, `Union Sq.`, and `Battery Park`.
-4. `Red` never found a single outer-node chain that matched the score pace of the center.
+## Where To Put Results
+- evergreen guidance stays in `docs/gameplay/`
+- versioned seeded runs go in:
+  - `docs/playtests/<version>/`
+- raw logs go in:
+  - `docs/playtests/<version>/raw/`
 
-## What The Log Suggests
-
-- The central corridor is still the most efficient route family.
-- Outer nodes now have real utility, but not enough to become the dominant plan by default.
-- `Battery Park` is doing useful work as a split point.
-- `Grove St` and `Hoboken` feel strategically real, not decorative.
-- The `Newark Airport -> Hudson Yards` tunnel is flavorful but expensive enough to stay situational.
-
-## Review Questions
-
-- Is the central trunk still too score-efficient relative to outer branches?
-- Are the outer-node tickets valuable enough to justify slower, safer play?
-- Should one or two central tickets be softened further, or is the current balance acceptable for a first playtest draft?
-
-## Log Source
-
-- Full raw log: `/tmp/hudson-hustle-agent-vs-agent-log.md`
-
-## Additional Run
-
-### Seed `1337`
-
-- Final score: `Blue 24`, `Red 33`
-- Winner: `Red`
-- Game length: `43` turns plus final scoring
-
-Notable differences from seed `42`:
-
-- `Red` found a cleaner outer-to-central bridge and used `Flushing`, `Exchange Place`, and `World Trade` more effectively.
-- `Blue` drew a weaker ticket mix for its central plan and never fully converted `Newark / Downtown Brooklyn` pressure into enough score.
-- This run looks more balanced than seed `42`, which is useful because it shows the map is not always a central blowout.
-
-Raw log:
-
-- `/tmp/hudson-hustle-agent-vs-agent-log-seed-1337.md`
+## Current Historical Example
+For the earlier small-map balance cycle, see:
+- [v0.4 agent-vs-agent playtest](/Users/djfan/Workspace/HudsonHustle/docs/playtests/v0.4/agent-vs-agent-playtest.md)

--- a/docs/planning/v2-status.md
+++ b/docs/planning/v2-status.md
@@ -1,7 +1,7 @@
 # V2 Status
 
 ## Summary
-`V2` is now in active implementation, but `v2.0 / MVP2` is not finished yet.
+`V2` is now in active implementation, and `v2.0` has cleared its first manual staging validation pass.
 
 The core architecture is in place:
 - separate-device multiplayer shell exists
@@ -39,51 +39,47 @@ The remaining work is mostly validation and hardening, not first-principles arch
   - `develop`
   - working branches
 - CI is active
+- `develop` manual staging validation completed on `2026-04-02`:
+  - deployed preview loaded
+  - room create / join / ready / start worked
+  - realtime lobby presence recovered in manual browser testing
+  - multiplayer game flow was playable on deployed staging
 
 ## V2.0 Still Missing
-These are the main gates before `v2.0 / MVP2` should be treated as complete.
+These are the main gates before `v2.0` should be treated as complete.
 
-### 1. Staging Smoke Pass
-- run a full `develop` multiplayer smoke pass on deployed staging
-- validate:
-  - create room
-  - join from second client
-  - ready / start
-  - private info isolation
-  - draw-two-card flow
-  - end turn handoff
-  - reconnect after refresh
-  - timer behavior
-  - both released maps
+### 1. Promote Toward Main
+- prepare `develop -> main` promotion once the current staging result is accepted
+- after merge to `main`, confirm:
+  - `Vercel` production updated
+  - `Railway` `api` updated
+  - production `/health` is healthy
 
-### 2. Merge / Promotion
-- merge the current MVP2 PR into `develop`
-- confirm:
-  - `develop` preview frontend deploys correctly
-  - `api-develop` staging backend deploys from `develop`
-- only after staging is trusted should MVP2 promotion toward `main` happen
-
-### 3. Browser-Level Regression Coverage
-- current automated coverage is still mostly service-level
-- add browser/E2E coverage for:
-  - reconnect UX
-  - private/public state separation
-  - timer display and timeout behavior
-  - lobby connected badge behavior
-
-### 4. Remote Multi-Device Validation
+### 2. Remote Multi-Device Validation
 - complete at least one real remote game flow with:
   - two browsers on separate devices
   - deployed frontend + deployed backend
 - confirm there is no environment-only desync or CORS/session issue
 
-### 5. Multiplayer Hardening
+### 3. Multiplayer Hardening
 - improve error states and UX around:
   - invalid room code
   - wrong credentials
   - seat already taken
   - socket failure after HTTP rejoin
   - backend restart / reconnect recovery
+
+### 4. Production-Side Observation
+- watch the first production deploy for:
+  - realtime handshake regressions
+  - preview/prod env drift
+  - unexpected platform-only behavior
+
+## Current Interpretation
+- staging confidence is now materially better than before
+- manual staging testing has passed
+- final production promotion is still pending
+- `v2.0` should be treated as late-stage integration work, not fully closed
 
 ## Explicitly Not In V2.0
 - public bot seats
@@ -95,8 +91,8 @@ These are the main gates before `v2.0 / MVP2` should be treated as complete.
 - matchmaking
 
 ## Recommended Next Order
-1. Merge current MVP2 work into `develop`
-2. Run the staging smoke checklist
-3. Fix any staging-only regressions
-4. Add targeted E2E coverage for the highest-risk multiplayer flows
-5. Only then decide whether to promote MVP2 toward `main`
+1. Record the successful staging smoke result
+2. Decide whether to promote `develop -> main`
+3. After merge to `main`, run production deploy checks
+4. Complete one more real remote multiplayer session on production
+5. Only then decide whether `v2.0` should be called complete

--- a/docs/playtests/v0.4/2p-central-choke-checklist.md
+++ b/docs/playtests/v0.4/2p-central-choke-checklist.md
@@ -1,5 +1,9 @@
 # v0.4 2-Player Central Choke Checklist
 
+Historical note:
+- this checklist was written for the `v0.4-next-wave` draft-phase review
+- keep that naming as a historical reference point, not as the current release label
+
 ## Purpose
 - Run one focused `2-player` manual playtest.
 - Check whether too many game plans collapse into the same central Manhattan core.

--- a/docs/playtests/v0.4/agent-vs-agent-playtest.md
+++ b/docs/playtests/v0.4/agent-vs-agent-playtest.md
@@ -1,5 +1,9 @@
 # v0.4 Agent Vs Agent Playtest
 
+Historical note:
+- this seeded report was captured during the `v0.4-next-wave` draft cycle
+- keep that draft name as historical context rather than current release naming
+
 This document captures seeded self-play runs on the active `v0.4-next-wave` draft using the `how-to-win-hudson-hustle` strategy skill.
 
 Artifacts:

--- a/docs/playtests/v0.4/balance-review.md
+++ b/docs/playtests/v0.4/balance-review.md
@@ -1,5 +1,9 @@
 # v0.4 Next Wave Balance Review
 
+Historical note:
+- this document records the draft-phase review before the frozen release was named `v0.4-flushing-newark-airport`
+- `v0.4-next-wave` here is intentional historical naming, not the current active release id
+
 ## Scope
 - Snapshot reviewed:
   - `configs/hudson-hustle/drafts/v0.4-next-wave`

--- a/docs/playtests/v0.4/keep-tune-cut.md
+++ b/docs/playtests/v0.4/keep-tune-cut.md
@@ -1,5 +1,9 @@
 # v0.4 Keep / Tune / Cut
 
+Historical note:
+- this triage uses the draft-era name `v0.4-next-wave`
+- it documents the tuning phase that led toward the later frozen `v0.4-flushing-newark-airport` release
+
 ## Purpose
 - Turn the current `v0.4-next-wave` review into a concrete triage list.
 - Separate what already feels right from what should be tuned next and what is most expendable.

--- a/docs/playtests/v0.4/tuning-candidates.md
+++ b/docs/playtests/v0.4/tuning-candidates.md
@@ -1,5 +1,9 @@
 # v0.4 Tuning Candidate List
 
+Historical note:
+- the applied tests below were recorded during the `v0.4-next-wave` draft cycle
+- keep this wording as draft-phase history, not as the name of the shipped release
+
 ## Purpose
 - Turn the high-level balance review into concrete tuning candidates.
 - Keep these as candidate changes, not committed balance decisions.

--- a/docs/playtests/v2.0/README.md
+++ b/docs/playtests/v2.0/README.md
@@ -1,0 +1,16 @@
+# V2.0 Playtests
+
+This folder is for multiplayer validation artifacts for `v2.0`.
+
+## Current Focus
+- manual staging smoke has passed on `develop`
+- production promotion is the next gate
+- reconnect and timer behavior
+- private/public state separation
+- multi-device validation on `develop`
+
+## Suggested Contents
+- staging smoke checklist
+- staging run notes
+- remote device test results
+- post-merge validation notes for `develop`

--- a/docs/playtests/v2.0/staging-smoke-checklist.md
+++ b/docs/playtests/v2.0/staging-smoke-checklist.md
@@ -1,0 +1,47 @@
+# V2.0 Staging Smoke Checklist
+
+Run this on the deployed `develop` environment after meaningful multiplayer merges.
+
+## Latest Result
+- `2026-04-02`: passed on `develop`
+- validated manually on deployed staging after the realtime handshake fix
+- confirmed:
+  - frontend preview loaded
+  - room create / join worked
+  - connected badges recovered from `Offline`
+  - ready / start worked
+  - multiplayer game flow was playable
+
+## Backend
+- staging backend `/health` returns `200`
+- released configs list is correct
+
+## Frontend
+- staging frontend loads without a blank screen
+- create/join UI is visible
+
+## Room Lifecycle
+- create room succeeds
+- second client can join
+- ready/start succeeds
+
+## Multiplayer Flow
+- each seat only sees its own hand and tickets
+- public board state matches on both clients
+- drawing two cards works
+- end turn hands control to the next player
+
+## Recovery
+- refresh reconnects to the same seat
+- invalid credentials show a real error state
+- lobby connected badge tracks websocket presence correctly
+
+## Timer
+- untimed room stays untimed
+- timed room shows the configured timeout
+- timer countdown appears active during play
+- timeout does not deadlock the room
+
+## Maps
+- `v0.3-atlantic-hoboken` can start
+- `v0.4-flushing-newark-airport` can start

--- a/docs/product/tech-spec.md
+++ b/docs/product/tech-spec.md
@@ -1,10 +1,16 @@
 # Hudson Hustle Tech Spec
 
 ## Architecture
-- `apps/web`: React + TypeScript + Vite client.
-- `packages/game-core`: pure rules engine with deterministic reducers and seeded randomness.
-- `packages/game-data`: NYC/NJ board layout, routes, tickets, and tuning constants.
-- `apps/server`: deferred until v2.
+- `apps/web`: React + TypeScript + Vite client for same-laptop play and separate-device multiplayer UI.
+- `apps/server`: Fastify + Socket.IO authoritative backend for rooms, reconnect, realtime sync, and multiplayer validation.
+- `packages/game-core`: pure rules engine with deterministic reducers, shared multiplayer transport types, and seeded randomness.
+- `packages/game-data`: NYC/NJ board layout, routes, tickets, tuning constants, and released-config registry data.
+
+## Runtime Split
+- `V1` runs entirely through `apps/web`, using the shared rules engine locally.
+- `V2` keeps gameplay rules in `packages/game-core`, but moves room lifecycle and authoritative state ownership into `apps/server`.
+- Clients submit intent; the server validates and broadcasts resulting public/private projections.
+- `packages/game-data` remains the shared source for released maps and balance data across both `web` and `server`.
 
 ## State Model
 - `GameState` contains players, route claims, station placements, public market, decks, score state, turn state, RNG state, and final-round bookkeeping.


### PR DESCRIPTION
## Summary

This PR refines the current V2 documentation set and replaces the temporary MVP2 delivery skill with a more general Hudson Hustle engineering manager skill.

## What changed

- updated `docs/product/tech-spec.md` so V2 architecture matches the real repo
- tightened `docs/planning/v2-status.md` to reflect manual staging validation and pending production promotion
- rewrote `docs/gameplay/agent-vs-agent-playtest.md` into an evergreen guide and kept historical runs in `docs/playtests/v0.4/`
- renamed `docs/playtests/mvp2/` to `docs/playtests/v2.0/`
- marked old `v0.4-next-wave` references as historical where appropriate
- added `hudson-hustle-engineering-manager` skill
- clarified the boundary between `roadmap-manager` and `hudson-hustle-engineering-manager`
- added merge-gate reference guidance
- updated merge expectations so docs review happens before merges to `develop` or `main`

## Notes

This is a docs/skill/repo-structure cleanup PR. No runtime behavior changes are included.
