### PR TITLE
Fix create room feedback for local multiplayer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 PORT=8787
-CORS_ORIGIN=http://127.0.0.1:5173,http://127.0.0.1:4173,http://localhost:5173,http://localhost:4173
+CORS_ORIGIN=http://127.0.0.1:5173,http://127.0.0.1:5174,http://127.0.0.1:4173,http://localhost:5173,http://localhost:5174,http://localhost:4173
 DATABASE_URL=
 PGHOST=
 PGPORT=

--- a/README.md
+++ b/README.md
@@ -54,10 +54,24 @@ When your turn is finished, click `I'm done`. The app hides your private informa
 pnpm install
 ```
 
-### Run The Web App
+### Run Local Pass-And-Play
 ```bash
 pnpm dev
 ```
+
+### Run Multiplayer Locally
+Open two terminals:
+
+```bash
+pnpm dev:server
+pnpm dev:web
+```
+
+The local multiplayer defaults are:
+- web: `http://127.0.0.1:5173`
+- server: `http://127.0.0.1:8787`
+
+If Vite falls back to `5174`, the default local CORS examples allow that port too.
 
 ### Test
 ```bash

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -1,5 +1,5 @@
 PORT=8787
-CORS_ORIGIN=http://127.0.0.1:5173,http://127.0.0.1:4173,http://localhost:5173,http://localhost:4173
+CORS_ORIGIN=http://127.0.0.1:5173,http://127.0.0.1:5174,http://127.0.0.1:4173,http://localhost:5173,http://localhost:5174,http://localhost:4173
 DATABASE_URL=
 PGHOST=
 PGPORT=

--- a/apps/server/src/env.ts
+++ b/apps/server/src/env.ts
@@ -23,7 +23,7 @@ export function readServerEnv(): ServerEnv {
     port: Number(process.env.PORT ?? 8787),
     corsOrigin:
       process.env.CORS_ORIGIN ??
-      "http://127.0.0.1:5173,http://127.0.0.1:4173,http://localhost:5173,http://localhost:4173",
+      "http://127.0.0.1:5173,http://127.0.0.1:5174,http://127.0.0.1:4173,http://localhost:5173,http://localhost:5174,http://localhost:4173",
     databaseUrl: process.env.DATABASE_URL ?? buildDatabaseUrlFromPgEnv()
   };
 }

--- a/apps/server/tests/cors-origin.test.ts
+++ b/apps/server/tests/cors-origin.test.ts
@@ -3,29 +3,33 @@ import { createCorsOriginMatcher, createSocketIoCorsOriginMatcher } from "../src
 
 describe("createCorsOriginMatcher", () => {
   it("allows exact local origins and wildcard vercel origins", async () => {
-    const matcher = createCorsOriginMatcher(["https://*.vercel.app", "http://127.0.0.1:5173"]);
+    const matcher = createCorsOriginMatcher(["https://*.vercel.app", "http://127.0.0.1:5173", "http://127.0.0.1:5174"]);
 
     const allowPreview = await resolveOriginCheck(matcher, "https://hudson-hustle-git-develop-djfan1s-projects.vercel.app");
     const allowLocal = await resolveOriginCheck(matcher, "http://127.0.0.1:5173");
+    const allowFallbackLocal = await resolveOriginCheck(matcher, "http://127.0.0.1:5174");
     const blockOther = await resolveOriginCheck(matcher, "https://example.com");
 
     expect(allowPreview).toBe(true);
     expect(allowLocal).toBe(true);
+    expect(allowFallbackLocal).toBe(true);
     expect(blockOther).toBe(false);
   });
 });
 
 describe("createSocketIoCorsOriginMatcher", () => {
   it("allows exact local origins and wildcard vercel origins via callback", async () => {
-    const matcher = createSocketIoCorsOriginMatcher(["https://*.vercel.app", "http://127.0.0.1:5173"]);
+    const matcher = createSocketIoCorsOriginMatcher(["https://*.vercel.app", "http://127.0.0.1:5173", "http://127.0.0.1:5174"]);
 
     const allowPreview = await resolveOriginCheck(matcher, "https://hudson-hustle-git-develop-djfan1s-projects.vercel.app");
     const allowLocal = await resolveOriginCheck(matcher, "http://127.0.0.1:5173");
+    const allowFallbackLocal = await resolveOriginCheck(matcher, "http://127.0.0.1:5174");
     const allowNoOrigin = await resolveOriginCheck(matcher, undefined);
     const blockOther = await resolveOriginCheck(matcher, "https://example.com");
 
     expect(allowPreview).toBe(true);
     expect(allowLocal).toBe(true);
+    expect(allowFallbackLocal).toBe(true);
     expect(allowNoOrigin).toBe(true);
     expect(blockOther).toBe(false);
   });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -182,6 +182,7 @@ export default function App(): JSX.Element {
   const [roomPreview, setRoomPreview] = useState<RoomSnapshot["room"] | null>(null);
   const [reconnectState, setReconnectState] = useState<ReconnectState>("fresh");
   const [multiplayerError, setMultiplayerError] = useState<string | null>(null);
+  const [isCreatingRoom, setIsCreatingRoom] = useState(false);
   const [timer, setTimer] = useState<TimerUpdate | null>(null);
   const [timerNow, setTimerNow] = useState(() => Date.now());
   const [realtimeStatus, setRealtimeStatus] = useState<RealtimeStatus>("idle");
@@ -472,6 +473,8 @@ export default function App(): JSX.Element {
   }, [localIsActive, mapConfig, selectedRouteId, snapshot]);
 
   async function createRoom(form: CreateRoomRequest) {
+    setIsCreatingRoom(true);
+    setMultiplayerError(null);
     try {
       const response = await requestJson<CreateRoomResponse>("/rooms", {
         method: "POST",
@@ -489,7 +492,15 @@ export default function App(): JSX.Element {
       setSnapshot(response.snapshot);
       setMultiplayerError(null);
     } catch (caught) {
-      setMultiplayerError(caught instanceof Error ? caught.message : "Could not create the room.");
+      setMultiplayerError(
+        caught instanceof TypeError
+          ? "Could not reach the multiplayer server. Make sure the local backend is running and this web port is allowed."
+          : caught instanceof Error
+            ? caught.message
+            : "Could not create the room."
+      );
+    } finally {
+      setIsCreatingRoom(false);
     }
   }
 
@@ -655,6 +666,7 @@ export default function App(): JSX.Element {
         reconnectState={reconnectState}
         roomPreview={roomPreview}
         error={multiplayerError}
+        isCreatingRoom={isCreatingRoom}
         onOpenLocal={() => {
           setSetupMode("local");
           setMultiplayerError(null);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -675,7 +675,10 @@ export default function App(): JSX.Element {
           setSetupMode("gateway");
           setMultiplayerError(null);
         }}
-        onClearRoomPreview={() => setRoomPreview(null)}
+        onClearRoomPreview={() => {
+          setRoomPreview(null);
+          setMultiplayerError(null);
+        }}
         onPreviewRoom={(roomCode) => void previewRoom(roomCode)}
         onCreateRoom={(form) => void createRoom(form)}
         onJoinRoom={(form) => void joinRoom(form)}

--- a/apps/web/src/components/MultiplayerSetupScreen.tsx
+++ b/apps/web/src/components/MultiplayerSetupScreen.tsx
@@ -21,6 +21,7 @@ interface MultiplayerSetupScreenProps {
   reconnectState: ReconnectState;
   roomPreview: RoomSummary | null;
   error: string | null;
+  isCreatingRoom?: boolean;
   onOpenLocal?: () => void;
   onBack?: () => void;
   onClearRoomPreview?: () => void;
@@ -39,6 +40,7 @@ export function MultiplayerSetupScreen({
   reconnectState,
   roomPreview,
   error,
+  isCreatingRoom = false,
   onOpenLocal,
   onBack,
   onClearRoomPreview,
@@ -138,7 +140,7 @@ export function MultiplayerSetupScreen({
         : "Enter a code, choose a seat, or restore a session.";
   const backLabel = stage === "gateway" ? "Back" : "Back";
   const showBanner =
-    stage === "join" && (Boolean(error) || reconnectState === "attempting-reconnect" || reconnectState === "reconnect-failed");
+    Boolean(error) || (stage === "join" && (reconnectState === "attempting-reconnect" || reconnectState === "reconnect-failed"));
   const railSteps =
     stage === "gateway"
       ? [
@@ -403,6 +405,7 @@ export function MultiplayerSetupScreen({
                     <Button onClick={() => setCreateStep(1)}>Back</Button>
                     <Button
                       variant="primary"
+                      disabled={isCreatingRoom}
                       onClick={() =>
                         onCreateRoom({
                           hostName: hostName.trim() || "Host",
@@ -413,7 +416,7 @@ export function MultiplayerSetupScreen({
                         })
                       }
                     >
-                      Create room
+                      {isCreatingRoom ? "Creating room..." : "Create room"}
                     </Button>
                   </div>
                 </Panel>

--- a/apps/web/tests/multiplayer.spec.ts
+++ b/apps/web/tests/multiplayer.spec.ts
@@ -196,6 +196,23 @@ test("invalid saved reconnect tokens fall back to the gateway instead of crashin
   await context.close();
 });
 
+test("switching from a failed join preview to create clears stale setup errors", async ({ browser }) => {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  await openMultiplayerSetup(page);
+  const joinPanel = await openJoinRoomPanel(page);
+  await joinPanel.getByLabel("Room code").fill("ABC123");
+  await joinPanel.getByRole("button", { name: "Preview" }).click();
+  await expect(page.getByText("Unknown room code.")).toBeVisible();
+
+  await page.getByRole("button", { name: "Start game" }).click();
+  await expect(page.getByTestId("create-room-panel")).toBeVisible();
+  await expect(page.getByText("Unknown room code.")).toHaveCount(0);
+
+  await context.close();
+});
+
 test("join flow clears stale seat selections when previewing a different room", async ({ browser }) => {
   const hostOneContext = await browser.newContext();
   const hostTwoContext = await browser.newContext();

--- a/docs/product/v2/v2-deployment.md
+++ b/docs/product/v2/v2-deployment.md
@@ -164,6 +164,7 @@ pnpm dev:web
 Defaults:
 - web: `http://127.0.0.1:5173`
 - server: `http://127.0.0.1:8787`
+- local CORS examples also allow `http://127.0.0.1:5174` for Vite fallback-port sessions
 
 ## First Branch-Based Deployment Checklist
 1. Create the `develop` branch in GitHub.


### PR DESCRIPTION
## Summary
- show create-room errors on the create flow instead of only the join flow
- add in-flight feedback while a room is being created
- allow the common Vite fallback port 5174 in local CORS defaults and tests

## Validation
- pnpm --filter @hudson-hustle/server test
- pnpm --filter @hudson-hustle/web build
- pnpm test:e2e (11 passed)