### PR TITLE
Fix route exhaustion endgame trigger

### DIFF
--- a/.codex/skills/how-to-win-hudson-hustle/SKILL.md
+++ b/.codex/skills/how-to-win-hudson-hustle/SKILL.md
@@ -115,6 +115,7 @@ Before acting, inspect:
   - claimed routes
   - still-open choke points
   - locked twin routes in `2-3` player games
+  - whether a claim would leave no route open and start the final round
   - face-up market cards
 - public opponent state:
   - claimed network shape

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Spend matching cards to take a route. Gray routes accept one color set. Ferries 
 Your destination tickets are your secret goals. Connect the two endpoints before the game ends to score them.
 
 ### Panel 4: Pass The Laptop
-When your turn is finished, click `I'm done`. The app hides your private information and shows a neutral takeover screen. The next player clicks `I'm ready`.
+When your turn is finished, click `I'm done`. The app hides your private information and shows a neutral takeover screen. The next player clicks `I'm ready`. The final round starts when a player runs low on trains or the board has no open routes left.
 
 ## Project Scope
 

--- a/apps/server/tests/bot-policy.test.ts
+++ b/apps/server/tests/bot-policy.test.ts
@@ -141,7 +141,7 @@ describe("chooseBotAction", () => {
     });
   });
 
-  it("uses only currently available routes when choosing which drawn ticket to keep", () => {
+  it("uses only currently open routes when choosing which drawn ticket to keep", () => {
     const ticketChoiceConfig: MapConfig = {
       id: "ticket-choice-map",
       name: "Ticket Choice Map",

--- a/apps/web/src/components/LocalPlayScreen.tsx
+++ b/apps/web/src/components/LocalPlayScreen.tsx
@@ -147,11 +147,11 @@ const tutorialSteps: TutorialStep[] = [
     summary:
       "The round table shows score, trains left, stations left, and ticket counts for every player. This is where you feel late-game pressure.",
     keyPoints: [
-      "The final round starts when a player ends a turn with two or fewer trains left.",
+      "The final round starts when a player ends a turn with two or fewer trains left, or when no route remains open.",
       "Unused stations are worth points, so building one is a tradeoff.",
       "Ticket counts can hint at who is still chasing risky plans."
     ],
-    tip: "Before drawing more tickets, glance at train counts so you do not overcommit late.",
+    tip: "Before drawing more tickets, glance at train counts and open routes so you do not overcommit late.",
     target: "scoreboard"
   },
   {

--- a/docs/gameplay/onboarding-script.md
+++ b/docs/gameplay/onboarding-script.md
@@ -45,6 +45,6 @@ This file defines the shipped `v1.1` guided tutorial flow.
 7. Action rail
   - show where legal moves and payments are confirmed
 8. Round table pressure
-  - explain trains left, stations left, ticket counts, and endgame pressure
+  - explain trains left, open routes, stations left, ticket counts, and endgame pressure
 9. Pass-and-play handoff
   - reinforce the social rhythm of one shared laptop

--- a/docs/gameplay/player-guide.md
+++ b/docs/gameplay/player-guide.md
@@ -123,7 +123,7 @@ Why stations are a tradeoff:
 - So a station is usually strongest when it saves a big ticket or bypasses a critical blockage.
 
 ## End Of The Game
-The final round starts when a player ends a turn with two or fewer trains remaining. Every other player gets one last turn.
+The final round starts when a player ends a turn with two or fewer trains remaining, or when a claimed route leaves no routes open on the board. Every other player gets one last turn.
 
 Then the game scores:
 1. route points already earned during play

--- a/docs/product/tech-spec.md
+++ b/docs/product/tech-spec.md
@@ -27,7 +27,7 @@
 - `3` stations per player.
 - Initial setup: one long ticket plus three regular tickets, keep at least two.
 - Standard route scoring curve: `1, 2, 4, 7, 10, 15`.
-- Final round triggers when a player ends a turn with `<= 2` trains.
+- Final round triggers when a player ends a turn with `<= 2` trains or when a route claim leaves no route open on the board.
 - Longest route bonus uses owned routes only.
 - Unused stations award endgame points.
 

--- a/docs/product/ubiquitous-language.md
+++ b/docs/product/ubiquitous-language.md
@@ -1,0 +1,17 @@
+# Hudson Hustle Ubiquitous Language
+
+## Route Availability
+
+Canonical player-facing term: `open route`.
+
+Definition:
+- An `open route` is not claimed and is not locked by a claimed twin route in a `2-3` player game.
+- An `affordable route` is an open route that the current player can pay for and has enough trains to claim.
+
+Usage:
+- Use `open route` for board-level availability and endgame pressure.
+- Use `affordable route` or payment-specific copy when explaining a player's current legal claim choices.
+- Avoid using `available route` when the distinction between board availability and affordability matters.
+
+Endgame boundary:
+- The final round starts when a player ends a turn with two or fewer trains remaining, or when a route claim leaves no open routes on the board.

--- a/packages/game-core/src/game.ts
+++ b/packages/game-core/src/game.ts
@@ -147,16 +147,8 @@ function getAvailableClaimColors(state: GameState, config: MapConfig, playerId: 
   const player = state.players.find((item) => item.id === playerId);
   invariant(player, "Unknown player.");
 
-  const locked = state.routeClaims.some((claim) => claim.routeId === routeId);
-  if (locked) {
+  if (!isRouteOpen(state, config, route)) {
     return [];
-  }
-
-  if (route.twinGroup && state.players.length <= 3) {
-    const twinIds = config.routes.filter((item) => item.twinGroup === route.twinGroup).map((item) => item.id);
-    if (state.routeClaims.some((claim) => twinIds.includes(claim.routeId))) {
-      return [];
-    }
   }
 
   if (player.trainsLeft < route.length) {
@@ -165,6 +157,23 @@ function getAvailableClaimColors(state: GameState, config: MapConfig, playerId: 
 
   const candidateColors = route.color === "gray" ? [...trainCardColors] : [route.color];
   return candidateColors.filter((color) => canPay(player.hand, color, route.length, route.locomotiveCost ?? 0));
+}
+
+function isRouteOpen(state: GameState, config: MapConfig, route: RouteDef): boolean {
+  if (state.routeClaims.some((claim) => claim.routeId === route.id)) {
+    return false;
+  }
+
+  if (route.twinGroup && state.players.length <= 3) {
+    const twinIds = config.routes.filter((item) => item.twinGroup === route.twinGroup).map((item) => item.id);
+    return !state.routeClaims.some((claim) => twinIds.includes(claim.routeId));
+  }
+
+  return true;
+}
+
+function hasOpenRoute(state: GameState, config: MapConfig): boolean {
+  return config.routes.some((route) => isRouteOpen(state, config, route));
 }
 
 function drawTickets(state: GameState, count: number, bucket: "regular" | "long"): TicketDef[] {
@@ -377,8 +386,8 @@ function beginAwaitingHandoff(state: GameState, summary: string): void {
   state.turn.summary = summary;
 }
 
-function maybeTriggerFinalRound(state: GameState, player: PlayerState): void {
-  if (state.finalRoundRemaining === null && player.trainsLeft <= 2) {
+function maybeTriggerFinalRound(state: GameState, config: MapConfig, player: PlayerState): void {
+  if (state.finalRoundRemaining === null && (player.trainsLeft <= 2 || !hasOpenRoute(state, config))) {
     state.finalRoundRemaining = state.players.length - 1;
     state.finalRoundTriggeredBy = player.id;
     appendLog(state, `${player.name} triggered the final round.`);
@@ -565,7 +574,7 @@ export function reduceGame(state: GameState, action: GameAction, config: MapConf
         cardsSpent: payment.spent,
         tunnelExtraCost
       });
-      maybeTriggerFinalRound(nextState, player);
+      maybeTriggerFinalRound(nextState, config, player);
       beginAwaitingHandoff(nextState, `${player.name} claimed ${route.id}.`);
       appendLog(nextState, `${player.name} claimed ${route.id} for ${routeScoreTable[route.length] ?? route.length * 2} points.`);
       return nextState;

--- a/packages/game-core/tests/game.test.ts
+++ b/packages/game-core/tests/game.test.ts
@@ -20,7 +20,7 @@ function forcePlayerHand(state: GameState, colors: Array<GameState["players"][nu
   return nextState;
 }
 
-function finishInitialTickets(state: GameState): GameState {
+function finishInitialTickets(state: GameState, config: MapConfig = hudsonHustleMap): GameState {
   let nextState = state;
   while (nextState.phase === "initialTickets") {
     const player = nextState.players[nextState.activePlayerIndex];
@@ -30,11 +30,64 @@ function finishInitialTickets(state: GameState): GameState {
         type: "select_initial_tickets",
         keptTicketIds: player.pendingTickets.slice(0, 2).map((ticket) => ticket.id)
       },
-      hudsonHustleMap
+      config
     );
   }
   return nextState;
 }
+
+const exhaustedDoubleRouteMap: MapConfig = {
+  id: "exhausted-double-route-test",
+  name: "Exhausted Double Route Test",
+  cities: [
+    { id: "alpha", name: "Alpha", x: 0, y: 0 },
+    { id: "bravo", name: "Bravo", x: 100, y: 0 }
+  ],
+  routes: [
+    {
+      id: "alpha-bravo-a",
+      from: "alpha",
+      to: "bravo",
+      length: 2,
+      color: "obsidian",
+      type: "normal",
+      twinGroup: "alpha-bravo"
+    },
+    {
+      id: "alpha-bravo-b",
+      from: "alpha",
+      to: "bravo",
+      length: 2,
+      color: "amber",
+      type: "normal",
+      twinGroup: "alpha-bravo"
+    }
+  ],
+  tickets: [
+    { id: "long-1", from: "alpha", to: "bravo", points: 5, bucket: "long" },
+    { id: "long-2", from: "alpha", to: "bravo", points: 5, bucket: "long" },
+    { id: "long-3", from: "alpha", to: "bravo", points: 5, bucket: "long" },
+    { id: "long-4", from: "alpha", to: "bravo", points: 5, bucket: "long" },
+    { id: "regular-1", from: "alpha", to: "bravo", points: 3, bucket: "regular" },
+    { id: "regular-2", from: "alpha", to: "bravo", points: 3, bucket: "regular" },
+    { id: "regular-3", from: "alpha", to: "bravo", points: 3, bucket: "regular" },
+    { id: "regular-4", from: "alpha", to: "bravo", points: 3, bucket: "regular" },
+    { id: "regular-5", from: "alpha", to: "bravo", points: 3, bucket: "regular" },
+    { id: "regular-6", from: "alpha", to: "bravo", points: 3, bucket: "regular" },
+    { id: "regular-7", from: "alpha", to: "bravo", points: 3, bucket: "regular" },
+    { id: "regular-8", from: "alpha", to: "bravo", points: 3, bucket: "regular" },
+    { id: "regular-9", from: "alpha", to: "bravo", points: 3, bucket: "regular" },
+    { id: "regular-10", from: "alpha", to: "bravo", points: 3, bucket: "regular" },
+    { id: "regular-11", from: "alpha", to: "bravo", points: 3, bucket: "regular" },
+    { id: "regular-12", from: "alpha", to: "bravo", points: 3, bucket: "regular" }
+  ],
+  settings: {
+    trainsPerPlayer: 8,
+    stationsPerPlayer: 3,
+    longestRouteBonus: 10,
+    stationValue: 4
+  }
+};
 
 function connectedCityCount(): number {
   const visited = new Set<string>();
@@ -650,6 +703,7 @@ describe("game-core", () => {
     );
     expect(state.routeClaims).toHaveLength(1);
     expect(state.players[0].trainsLeft).toBe(hudsonHustleMap.settings.trainsPerPlayer - 2);
+    expect(state.finalRoundRemaining).toBeNull();
     expect(state.turn.stage).toBe("awaitingHandoff");
   });
 
@@ -665,6 +719,42 @@ describe("game-core", () => {
         hudsonHustleMap
       )
     ).toThrow("You do not have enough trains left for that route.");
+  });
+
+  it("triggers the final round when no route remains open", () => {
+    let state = finishInitialTickets(
+      startGame(exhaustedDoubleRouteMap, { playerNames: ["A", "B"], seed: 9 }),
+      exhaustedDoubleRouteMap
+    );
+    state = forcePlayerHand(state, ["obsidian", "obsidian"]);
+
+    state = reduceGame(
+      state,
+      { type: "claim_route", routeId: "alpha-bravo-a", color: "obsidian" },
+      exhaustedDoubleRouteMap
+    );
+
+    expect(state.players[0].trainsLeft).toBe(6);
+    expect(state.finalRoundRemaining).toBe(1);
+    expect(state.finalRoundTriggeredBy).toBe("player-1");
+  });
+
+  it("does not trigger route-exhaustion endgame while a 4-player double route twin remains open", () => {
+    let state = finishInitialTickets(
+      startGame(exhaustedDoubleRouteMap, { playerNames: ["A", "B", "C", "D"], seed: 9 }),
+      exhaustedDoubleRouteMap
+    );
+    state = forcePlayerHand(state, ["obsidian", "obsidian"]);
+
+    state = reduceGame(
+      state,
+      { type: "claim_route", routeId: "alpha-bravo-a", color: "obsidian" },
+      exhaustedDoubleRouteMap
+    );
+
+    expect(state.players[0].trainsLeft).toBe(6);
+    expect(state.finalRoundRemaining).toBeNull();
+    expect(state.finalRoundTriggeredBy).toBeNull();
   });
 
   it("builds a station and consumes cards", () => {


### PR DESCRIPTION
## Summary
- trigger the final round when a successful route claim leaves no open routes on the board
- keep the existing two-or-fewer-trains trigger unchanged
- align player guide, onboarding, tech spec, README, and strategy terminology around open routes

## Review notes
- no blocking issues found in final review
- route exhaustion checks board-level open routes, including locked twin routes in 2-3 player games
- 4-player double-route twins remain open after one side is claimed

## Validation
- pnpm test
- pnpm build
- git diff --check