### PR TITLE
Update CI actions for Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,15 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9.12.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm


### PR DESCRIPTION
## Summary
- update CI workflow action majors to Node 24-based versions
- keep the project test runtime on Node 20 for now
- resolves the GitHub Actions Node 20 deprecation annotation tracked in #67

## Validation
- pnpm test
- pnpm build
- git diff --check

Closes #67