### PR TITLE
fix(deploy): bypass Corepack + design system component audit

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -44,6 +44,7 @@ import {
   SupplyDock,
   TicketChoiceSheet,
   TicketDock,
+  TurnIndicator,
   formatCardLabel,
   type GameplayNotification
 } from "./components/GameplayHud";
@@ -890,13 +891,10 @@ export default function App(): JSX.Element {
     <div className="app-shell app-shell--gameplay-hud" data-config-theme={visuals.theme}>
       <header className="topbar topbar--gameplay-actions">
         <div className="topbar-private-spacer" aria-hidden="true" />
-        <div className="turn-indicator">
-          <span className="turn-indicator__name">{projectedGame.players[snapshot.game.activePlayerIndex]?.name}</span>
-          <span className="turn-indicator__label">active</span>
-          {liveTimerSecondsRemaining !== null && (
-            <span className="turn-indicator__timer">{liveTimerSecondsRemaining}s</span>
-          )}
-        </div>
+        <TurnIndicator
+          playerName={projectedGame.players[snapshot.game.activePlayerIndex]?.name ?? ""}
+          secondsRemaining={liveTimerSecondsRemaining}
+        />
         <div className="topbar-actions">
           <Button onClick={() => setGuideOpen(true)}>Guide</Button>
           <ScoreGuide className="score-guide--subtle" label="Score" />

--- a/apps/web/src/components/GameplayHud.tsx
+++ b/apps/web/src/components/GameplayHud.tsx
@@ -10,6 +10,7 @@ import {
   type TrainCardFace
 } from "@hudson-hustle/game-core";
 import { Button } from "./system/Button";
+import { FormField } from "./system/FormField";
 import { Panel } from "./system/Panel";
 import { SectionHeader } from "./system/SectionHeader";
 import {
@@ -19,11 +20,12 @@ import {
   SeatTile,
   SideTabRail,
   TicketSlip,
+  TurnIndicator,
   formatCardLabel,
   type GameplayNotification
 } from "./system/game";
 
-export { formatCardLabel, type GameplayNotification } from "./system/game";
+export { TurnIndicator, formatCardLabel, type GameplayNotification } from "./system/game";
 
 type InspectorTab = "market" | "build" | "chat";
 
@@ -528,7 +530,7 @@ export function InspectorDock({
               )}
             </div>
             {onSendChat ? (
-              <div className="chat-panel__composer" aria-label="Chat composer">
+              <FormField as="div" label="Message" className="chat-panel__composer">
                 <input
                   type="text"
                   placeholder="Message room"
@@ -543,7 +545,7 @@ export function InspectorDock({
                     }
                   }}
                 />
-              </div>
+              </FormField>
             ) : null}
           </form>
         </div>

--- a/apps/web/src/components/LocalPlayScreen.tsx
+++ b/apps/web/src/components/LocalPlayScreen.tsx
@@ -35,6 +35,7 @@ import {
   SupplyDock,
   TicketChoiceSheet,
   TicketDock,
+  TurnIndicator,
   formatCardLabel,
   type GameplayNotification
 } from "./GameplayHud";
@@ -516,10 +517,7 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
     <div className="app-shell app-shell--gameplay-hud" data-config-theme={localVisuals.theme}>
       <header className="topbar topbar--gameplay-actions">
         <div className="topbar-private-spacer" aria-hidden="true" />
-        <div className="turn-indicator">
-          <span className="turn-indicator__name">{game.players[game.activePlayerIndex]?.name}</span>
-          <span className="turn-indicator__label">active</span>
-        </div>
+        <TurnIndicator playerName={game.players[game.activePlayerIndex]?.name ?? ""} />
         <div className="topbar-actions">
           <Button onClick={openTutorial}>
             Guide

--- a/apps/web/src/components/MultiplayerSetupScreen.tsx
+++ b/apps/web/src/components/MultiplayerSetupScreen.tsx
@@ -17,6 +17,7 @@ import {
   type SetupStep
 } from "./setup";
 import { Button } from "./system/Button";
+import { TimerPicker } from "./system/TimerPicker";
 
 interface CreateRoomForm {
   hostName: string;
@@ -475,13 +476,7 @@ export function MultiplayerSetupScreen({
             >
               <div className="setup-timer-preflight">
                 <FormField as="div" label="Timer" className="form-field--timer" helper="Enter seconds. 0 = untimed · 30 = 30 s · 60 = 1 min.">
-                  <div className="timer-picker">
-                    <Button onClick={() => setTurnTimeLimitSeconds((current) => Math.max(0, current - 15))}>-15</Button>
-                    <output className="timer-picker__value" aria-live="polite">
-                      {turnTimeLimitSeconds === 0 ? "Untimed" : `${turnTimeLimitSeconds}s`}
-                    </output>
-                    <Button onClick={() => setTurnTimeLimitSeconds((current) => current + 15)}>+15</Button>
-                  </div>
+                  <TimerPicker value={turnTimeLimitSeconds} onChange={setTurnTimeLimitSeconds} />
                 </FormField>
               </div>
             </SetupStepPanel>

--- a/apps/web/src/components/SetupGateway.tsx
+++ b/apps/web/src/components/SetupGateway.tsx
@@ -1,3 +1,4 @@
+import { Button } from "./system";
 import { DepartureBoardTile, SetupShell, type SetupStep } from "./setup";
 
 interface SetupGatewayProps {
@@ -46,15 +47,14 @@ export function SetupGateway({ onChooseLocal, onChooseOnline, onOpenGuide }: Set
           status=""
         />
       </div>
-      <button
-        type="button"
+      <Button
         className="setup-guide-link"
         onClick={onOpenGuide}
         data-testid="gateway-onboarding"
         aria-label="Open the guide"
       >
         First time? Open the rulebook →
-      </button>
+      </Button>
     </SetupShell>
   );
 }

--- a/apps/web/src/components/SetupScreen.tsx
+++ b/apps/web/src/components/SetupScreen.tsx
@@ -12,6 +12,7 @@ import {
 } from "./setup";
 import { Button } from "./system/Button";
 import { FormField } from "./system/FormField";
+import { TimerPicker } from "./system/TimerPicker";
 import type { HudsonHustleReleasedConfigSummary } from "@hudson-hustle/game-data";
 
 interface LocalStartSetup {
@@ -258,13 +259,7 @@ export function SetupScreen({
           >
             <div className="setup-timer-preflight">
               <FormField as="div" label="Timer" className="form-field--timer" helper="Enter seconds. 0 = untimed · 30 = 30 s · 60 = 1 min.">
-                <div className="timer-picker">
-                  <Button onClick={() => setTurnTimeLimitSeconds((current) => Math.max(0, current - 15))}>-15</Button>
-                  <output className="timer-picker__value" aria-live="polite">
-                    {turnTimeLimitSeconds === 0 ? "Untimed" : `${turnTimeLimitSeconds}s`}
-                  </output>
-                  <Button onClick={() => setTurnTimeLimitSeconds((current) => current + 15)}>+15</Button>
-                </div>
+                <TimerPicker value={turnTimeLimitSeconds} onChange={setTurnTimeLimitSeconds} />
               </FormField>
             </div>
           </SetupStepPanel>

--- a/apps/web/src/components/system/TimerPicker.tsx
+++ b/apps/web/src/components/system/TimerPicker.tsx
@@ -1,0 +1,19 @@
+import { Button } from "./Button";
+
+interface TimerPickerProps {
+  value: number;
+  onChange: (value: number) => void;
+  step?: number;
+}
+
+export function TimerPicker({ value, onChange, step = 15 }: TimerPickerProps): JSX.Element {
+  return (
+    <div className="timer-picker">
+      <Button onClick={() => onChange(Math.max(0, value - step))}>-{step}</Button>
+      <output className="timer-picker__value" aria-live="polite">
+        {value === 0 ? "Untimed" : `${value}s`}
+      </output>
+      <Button onClick={() => onChange(value + step)}>+{step}</Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/system/game/TurnIndicator.tsx
+++ b/apps/web/src/components/system/game/TurnIndicator.tsx
@@ -1,0 +1,16 @@
+interface TurnIndicatorProps {
+  playerName: string;
+  secondsRemaining?: number | null;
+}
+
+export function TurnIndicator({ playerName, secondsRemaining }: TurnIndicatorProps): JSX.Element {
+  return (
+    <div className="turn-indicator">
+      <span className="turn-indicator__name">{playerName}</span>
+      <span className="turn-indicator__label">active</span>
+      {secondsRemaining != null && (
+        <span className="turn-indicator__timer">{secondsRemaining}s</span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/system/game/index.ts
+++ b/apps/web/src/components/system/game/index.ts
@@ -9,3 +9,4 @@ export { SideTabRail } from "./SideTabRail";
 export type { SideTab } from "./SideTabRail";
 export { TicketSlip } from "./TicketSlip";
 export type { TicketSlipStatus } from "./TicketSlip";
+export { TurnIndicator } from "./TurnIndicator";

--- a/apps/web/src/components/system/index.ts
+++ b/apps/web/src/components/system/index.ts
@@ -10,4 +10,5 @@ export { SectionHeader } from "./SectionHeader";
 export { StateSurface } from "./StateSurface";
 export { StatusBanner } from "./StatusBanner";
 export { SurfaceCard } from "./SurfaceCard";
+export { TimerPicker } from "./TimerPicker";
 export { UtilityPill } from "./UtilityPill";

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,5 @@
+# Disable Corepack so pnpm is installed via npm rather than fetched from the
+# npm registry at build time. Corepack network failures are transient but
+# frequent on Railway; this makes the build resilient to registry downtime.
+[phases.setup]
+cmds = ["corepack disable", "npm install -g pnpm@9.12.0"]


### PR DESCRIPTION
## Summary

- **Fix Railway build failure**: Adds `nixpacks.toml` to disable Corepack and install pnpm via npm directly, preventing transient npm registry TLS failures from breaking the build
- **Design system audit**: Extracted `TimerPicker` and `TurnIndicator` as reusable system components; replaced all raw `<button>` and bare `<input>` elements with system components across the UI

## Changes

### Deploy fix
- `nixpacks.toml` — disables Corepack, installs `pnpm@9.12.0` via `npm install -g` instead of fetching from registry at build time

### New system components
- `system/TimerPicker` — shared -N/+N stepper, replaces duplicated timer control in `SetupScreen` and `MultiplayerSetupScreen`
- `system/game/TurnIndicator` — active player name + countdown, replaces duplicated inline spans in `App.tsx` and `LocalPlayScreen`

### Component adoption fixes
- `SetupGateway` — raw `<button>` → `<Button>`
- `GameplayHud` — bare chat `<input>` → `<FormField>` wrapper

## Test plan
- [ ] Trigger a Railway deploy from this branch — build should complete without Corepack errors
- [ ] Verify Setup flow (local + multiplayer) timer picker still works
- [ ] Verify turn indicator renders correctly in both local and multiplayer gameplay
- [ ] Verify guide link in SetupGateway still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)