### PR TITLE
feat: wire error state + gameplay Storybook stories

### DIFF
--- a/apps/web/src/components/LocalPlayScreen.tsx
+++ b/apps/web/src/components/LocalPlayScreen.tsx
@@ -47,6 +47,7 @@ import { Button } from "./system/Button";
 import { ChoiceChipButton } from "./system/ChoiceChipButton";
 import { ModalShell } from "./system/ModalShell";
 import { Panel } from "./system/Panel";
+import { StatusBanner } from "./system/StatusBanner";
 import { SectionHeader } from "./system/SectionHeader";
 import { SurfaceCard } from "./system/SurfaceCard";
 
@@ -171,7 +172,7 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
   const [pinnedTicket, setPinnedTicket] = useState<TicketDef | null>(null);
   const [paymentPreview, setPaymentPreview] = useState<{ color: TrainCardColor; totalCost: number; minimumLocomotives?: number } | null>(null);
   const [revealedDeckCard, setRevealedDeckCard] = useState<keyof typeof cardColorPalette | null>(null);
-  const [, setError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const [guideOpen, setGuideOpen] = useState(false);
   const [hasSavedGame, setHasSavedGame] = useState<boolean>(() => typeof window !== "undefined" && Boolean(readSavedGame()));
   const [localConfigId, setLocalConfigId] = useState(hudsonHustleCurrentConfigId);
@@ -718,6 +719,10 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
               <SurfaceCard variant="detail" className="detail-card detail-card--tunnel" eyebrow="Tunnel check" title="Tunnel reveal">
                 <p>{game.turn.latestTunnelReveal.join(", ")}</p>
               </SurfaceCard>
+                ) : null}
+
+                {error && visibility === "visible" ? (
+                  <StatusBanner tone="warning" eyebrow="Action error" headline={error} />
                 ) : null}
               </>
             }

--- a/apps/web/src/components/gameplay/BoardStage.stories.tsx
+++ b/apps/web/src/components/gameplay/BoardStage.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { BoardStage } from "./BoardStage";
+
+const meta = {
+  title: "Gameplay/BoardStage",
+  component: BoardStage,
+  args: {
+    isMyTurn: false,
+    children: (
+      <div
+        style={{
+          width: "100%",
+          height: 320,
+          background: "var(--color-surface-subtle, #e8eef2)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          borderRadius: 4,
+          color: "var(--color-text-muted, #6b7a86)",
+          fontSize: 14
+        }}
+      >
+        Board map renders here
+      </div>
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Outer wrapper panel for the game board. Applies the `board-stage` shell and a `board-stage--my-turn` modifier when it is the viewer's active turn."
+      }
+    }
+  },
+  render: (args) => <BoardStage {...args} />
+} satisfies Meta<typeof BoardStage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Idle: Story = {};
+
+export const MyTurn: Story = {
+  args: {
+    isMyTurn: true
+  }
+};

--- a/apps/web/src/components/gameplay/InspectorDock.stories.tsx
+++ b/apps/web/src/components/gameplay/InspectorDock.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { TrainCard } from "@hudson-hustle/game-core";
+import { InspectorDock } from "./InspectorDock";
+import { SupplyDock } from "./SupplyDock";
+
+const cardPalette: Record<string, string> = {
+  crimson: "#c0392b",
+  cobalt: "#2980b9",
+  emerald: "#27ae60",
+  amber: "#f39c12",
+  violet: "#9b59b6",
+  rose: "#e91e8c",
+  ivory: "#ecf0f1",
+  obsidian: "#2c3e50",
+  locomotive: "#91a8bd"
+};
+
+const sampleMarket: TrainCard[] = [
+  { id: "card-1", color: "crimson" },
+  { id: "card-2", color: "cobalt" },
+  { id: "card-3", color: "locomotive" },
+  { id: "card-4", color: "emerald" },
+  { id: "card-5", color: "amber" }
+];
+
+const sampleMarketContent = (
+  <SupplyDock
+    market={sampleMarket}
+    deckCount={38}
+    cardPalette={cardPalette}
+    disabled={false}
+    onDrawFromMarket={() => undefined}
+    onDrawFromDeck={() => undefined}
+    onDrawTickets={() => undefined}
+  />
+);
+
+const sampleBuildContent = (
+  <div className="action-empty-prompt" data-testid="action-empty-state">
+    <span className="action-empty-prompt__title">Select a route or station.</span>
+    <span className="action-empty-prompt__copy">Build options appear here.</span>
+  </div>
+);
+
+const meta = {
+  title: "Gameplay/InspectorDock",
+  component: InspectorDock,
+  args: {
+    summary: null,
+    marketContent: sampleMarketContent,
+    buildContent: sampleBuildContent,
+    activeBuildKey: null,
+    currentPlayerName: "Rosa",
+    deckCount: 38,
+    ticketDeckCount: 14,
+    turnNumber: 7
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Right-rail panel housing the Market, Build, and Chat tabs. Automatically switches to the Build tab when `activeBuildKey` is set. Footer row surfaces turn metadata like current player name, deck counts, and turn number."
+      }
+    }
+  },
+  render: (args) => (
+    <div style={{ maxWidth: 360, minHeight: 480 }}>
+      <InspectorDock {...args} />
+    </div>
+  )
+} satisfies Meta<typeof InspectorDock>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const MarketTab: Story = {};
+
+export const BuildTab: Story = {
+  args: {
+    activeBuildKey: "route-abc",
+    summary: "Select a color to claim the route."
+  }
+};
+
+export const WithSummary: Story = {
+  args: {
+    summary: "Rosa drew a card from the market."
+  }
+};
+
+export const WithChat: Story = {
+  args: {
+    chatMessages: [
+      { id: "msg-1", playerName: "Rosa", message: "Nice move!" },
+      { id: "msg-2", playerName: "Milo", message: "Thanks, just getting warmed up." }
+    ],
+    onSendChat: () => undefined
+  }
+};
+
+export const LocalPlayNoChat: Story = {
+  args: {
+    chatMessages: [],
+    onSendChat: undefined
+  }
+};

--- a/apps/web/src/components/gameplay/PlayerRosterPanel.stories.tsx
+++ b/apps/web/src/components/gameplay/PlayerRosterPanel.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { FloatingPlayerRoster, PlayerRoster } from "./PlayerRosterPanel";
+
+const playerPalette: Record<string, string> = {
+  red: "#c0392b",
+  blue: "#2980b9",
+  green: "#27ae60",
+  yellow: "#f39c12"
+};
+
+const samplePlayers = [
+  { id: "player-1", name: "Rosa", color: "red", trainsLeft: 24, stationsLeft: 3, ticketCount: 3, avatarName: "Conductor" },
+  { id: "player-2", name: "Milo", color: "blue", trainsLeft: 19, stationsLeft: 2, ticketCount: 2, avatarName: "Engineer" },
+  { id: "player-3", name: "Jack", color: "green", trainsLeft: 32, stationsLeft: 3, ticketCount: 4, avatarName: "Dispatcher" },
+  { id: "player-4", name: "Lily", color: "yellow", trainsLeft: 11, stationsLeft: 1, ticketCount: 1, avatarName: "Caboose" }
+];
+
+const rosterMeta = {
+  title: "Gameplay/PlayerRoster",
+  component: PlayerRoster,
+  args: {
+    players: samplePlayers,
+    activePlayerIndex: 0,
+    playerPalette,
+    timer: null
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Scoreboard rail showing all player seats with train counts, ticket counts, and the active-player label. Renders up to four fixed-width SeatTile slots, filling empty seats with placeholder tiles."
+      }
+    }
+  },
+  render: (args) => (
+    <div style={{ maxWidth: 480 }}>
+      <PlayerRoster {...args} />
+    </div>
+  )
+} satisfies Meta<typeof PlayerRoster>;
+
+export default rosterMeta;
+type Story = StoryObj<typeof rosterMeta>;
+
+export const FourPlayers: Story = {};
+
+export const ActivePlayerTwo: Story = {
+  args: {
+    activePlayerIndex: 1
+  }
+};
+
+export const WithTimer: Story = {
+  args: {
+    activePlayerIndex: 0,
+    timer: { activePlayerIndex: 0, secondsRemaining: 28 }
+  }
+};
+
+export const TwoPlayers: Story = {
+  args: {
+    players: samplePlayers.slice(0, 2),
+    activePlayerIndex: 1
+  }
+};
+
+export const FloatingRoster: Story = {
+  render: () => (
+    <div style={{ position: "relative", width: 560, height: 360, background: "var(--color-surface-subtle, #e8eef2)", borderRadius: 8 }}>
+      <FloatingPlayerRoster
+        players={samplePlayers.slice(0, 3)}
+        activePlayerIndex={0}
+        playerPalette={playerPalette}
+        viewerPlayerId="player-1"
+      />
+    </div>
+  )
+};

--- a/apps/web/src/components/gameplay/SupplyDock.stories.tsx
+++ b/apps/web/src/components/gameplay/SupplyDock.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { TrainCard } from "@hudson-hustle/game-core";
+import { SupplyDock } from "./SupplyDock";
+
+const cardPalette: Record<string, string> = {
+  crimson: "#c0392b",
+  cobalt: "#2980b9",
+  emerald: "#27ae60",
+  amber: "#f39c12",
+  violet: "#9b59b6",
+  rose: "#e91e8c",
+  ivory: "#ecf0f1",
+  obsidian: "#2c3e50",
+  locomotive: "#91a8bd"
+};
+
+const sampleMarket: TrainCard[] = [
+  { id: "card-1", color: "crimson" },
+  { id: "card-2", color: "cobalt" },
+  { id: "card-3", color: "locomotive" },
+  { id: "card-4", color: "emerald" },
+  { id: "card-5", color: "amber" }
+];
+
+const meta = {
+  title: "Gameplay/SupplyDock",
+  component: SupplyDock,
+  args: {
+    market: sampleMarket,
+    deckCount: 42,
+    cardPalette,
+    disabled: false,
+    drawTicketsDisabled: false,
+    onDrawFromMarket: () => undefined,
+    onDrawFromDeck: () => undefined,
+    onDrawTickets: () => undefined
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Card market and draw controls for the active player. Shows five face-up market slots, a deck draw button, and an optional ticket draw button. All slots are disabled between draw steps or when it is not the viewer's turn."
+      }
+    }
+  },
+  render: (args) => (
+    <div style={{ maxWidth: 320 }}>
+      <SupplyDock {...args} />
+    </div>
+  )
+} satisfies Meta<typeof SupplyDock>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Active: Story = {};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true
+  }
+};
+
+export const TicketsDisabled: Story = {
+  args: {
+    drawTicketsDisabled: true
+  }
+};
+
+export const NoTicketDraw: Story = {
+  args: {
+    onDrawTickets: undefined
+  }
+};
+
+export const LowDeck: Story = {
+  args: {
+    deckCount: 3
+  }
+};


### PR DESCRIPTION
## Summary

- **LocalPlayScreen error display**: the `setError` state was being set on action failures but the read side was discarded (`[, setError]`). Now surfaces via `StatusBanner` (tone=warning) in the inspector dock area during active play.
- **Gameplay stories**: adds Storybook coverage for all four `gameplay/` components introduced in PR #79.

## Stories added

| File | Stories |
|------|---------|
| `BoardStage.stories.tsx` | `Idle`, `MyTurn` |
| `PlayerRosterPanel.stories.tsx` | `FourPlayers`, `TwoPlayers`, `WithTimer`, `FloatingRoster` |
| `SupplyDock.stories.tsx` | `Active`, `Disabled`, `TicketsDisabled`, `NoTicketDraw`, `LowDeck` |
| `InspectorDock.stories.tsx` | `MarketTab`, `BuildTab`, `WithSummary`, `WithChat`, `LocalPlayNoChat` |

## Test plan

- [ ] `pnpm --filter @hudson-hustle/web exec tsc --noEmit` passes
- [ ] Trigger an action error in local play (e.g. attempt to claim a route you can't afford) — StatusBanner appears in the inspector area
- [ ] Open Storybook and verify all four gameplay story groups render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)