### PR TITLE
refactor: decompose MultiplayerSetupScreen into components/multiplayer/

### DIFF
--- a/apps/web/src/components/MultiplayerSetupScreen.tsx
+++ b/apps/web/src/components/MultiplayerSetupScreen.tsx
@@ -1,33 +1,24 @@
 import { useEffect, useMemo, useState } from "react";
 import type { HudsonHustleReleasedConfigSummary } from "@hudson-hustle/game-data";
 import type { ReconnectState, RoomSummary } from "@hudson-hustle/game-core";
-import { FormField } from "./system/FormField";
 import { StateSurface } from "./system/StateSurface";
 import {
-  DepartureBoardTile,
-  MapThumbnail,
   ModeSwitch,
-  SeatPlan,
-  SetupActions,
   SetupBackButton,
   SetupShell,
-  SetupStepPanel,
-  SetupSummaryRow,
-  SetupTicketSlip,
-  TokenButton,
-  type SeatRow,
   type SetupStep
 } from "./setup";
-import { Button } from "./system/Button";
-import { TimerPicker } from "./system/TimerPicker";
-
-interface CreateRoomForm {
-  hostName: string;
-  playerCount: 2 | 3 | 4;
-  configId: string;
-  turnTimeLimitSeconds: number;
-  botSeatIds: string[];
-}
+import {
+  CreateRoomFlow,
+  CreateRoomPreflight,
+  JoinRoomFlow,
+  JoinRoomPreflight,
+  OnlineGateway,
+  getStepStatus,
+  type CreateRoomForm,
+  type OnlineSetupStage,
+  type SetupFlowStep
+} from "./multiplayer";
 
 interface MultiplayerSetupScreenProps {
   releasedConfigs: HudsonHustleReleasedConfigSummary[];
@@ -43,35 +34,34 @@ interface MultiplayerSetupScreenProps {
   onJoinRoom: (form: { roomCode: string; playerName: string; preferredSeatId?: string }) => void;
 }
 
-type OnlineSetupStage = "gateway" | "create" | "join";
-type SetupFlowStep = 0 | 1 | 2 | 3;
-
 export function MultiplayerSetupScreen({
   releasedConfigs,
   reconnectState,
   roomPreview,
   error,
   isCreatingRoom = false,
-  onOpenLocal,
   onBack,
   onClearRoomPreview,
   onPreviewRoom,
   onCreateRoom,
   onJoinRoom
 }: MultiplayerSetupScreenProps): JSX.Element {
-  const ROOM_CODE_LENGTH = 6;
   const setupHeroImageUrl = "/setup/landing-bg.png";
   const latestConfigId = releasedConfigs.at(-1)?.configId ?? "v0.4-flushing-newark-airport";
+
+  // Create form state
   const [hostName, setHostName] = useState("Host");
   const [playerCount, setPlayerCount] = useState<2 | 3 | 4>(2);
   const [configId, setConfigId] = useState(latestConfigId);
   const [turnTimeLimitSeconds, setTurnTimeLimitSeconds] = useState(0);
   const [botSeatIds, setBotSeatIds] = useState<string[]>([]);
 
+  // Join form state
   const [joinRoomCode, setJoinRoomCode] = useState("");
   const [joinPlayerName, setJoinPlayerName] = useState("Player");
   const [preferredSeatId, setPreferredSeatId] = useState<string | undefined>(undefined);
 
+  // Navigation state
   const [stage, setStage] = useState<OnlineSetupStage>(() =>
     reconnectState === "attempting-reconnect" || reconnectState === "reconnect-failed" ? "join" : "gateway"
   );
@@ -83,106 +73,28 @@ export function MultiplayerSetupScreen({
     [roomPreview]
   );
   const setupSeatIds = useMemo(
-    () => Array.from({ length: playerCount }, (_, index) => `seat-${index + 1}`),
+    () => Array.from({ length: playerCount }, (_, i) => `seat-${i + 1}`),
     [playerCount]
   );
-  const plannedBotCount = botSeatIds.filter((seatId) => seatId !== "seat-1" && setupSeatIds.includes(seatId)).length;
+  const plannedBotCount = botSeatIds.filter((id) => id !== "seat-1" && setupSeatIds.includes(id)).length;
   const plannedHumanOpenSeats = Math.max(0, playerCount - 1 - plannedBotCount);
-  const setupBannerTone = error || reconnectState === "reconnect-failed" ? "danger" : reconnectState === "attempting-reconnect" ? "waiting" : "neutral";
-  const setupBannerEyebrow =
-    error || reconnectState === "reconnect-failed" ? "Connection issue" : reconnectState === "attempting-reconnect" ? "Reconnect" : "Separate-device multiplayer";
-  const setupBannerHeadline =
-    error || reconnectState === "reconnect-failed"
-      ? "Multiplayer setup needs attention."
-      : reconnectState === "attempting-reconnect"
-        ? "Attempting to restore your room."
-        : "Create a room or join a table.";
-  const setupBannerCopy = error
-    ? error
-    : reconnectState === "reconnect-failed"
-      ? "Saved room recovery failed. Enter the room code again to board."
-      : reconnectState === "attempting-reconnect"
-        ? "Checking the saved room session first."
-        : "Host a table or join one by room code.";
+  const selectedConfig = releasedConfigs.find((c) => c.configId === configId);
 
   useEffect(() => {
-    if (reconnectState === "attempting-reconnect") {
-      setStage("join");
-      setJoinStep(2);
-      return;
-    }
-
-    if (reconnectState === "reconnect-failed") {
-      setStage("join");
-      setJoinStep(0);
-    }
+    if (reconnectState === "attempting-reconnect") { setStage("join"); setJoinStep(2); return; }
+    if (reconnectState === "reconnect-failed") { setStage("join"); setJoinStep(0); }
   }, [reconnectState]);
 
   useEffect(() => {
-    if (stage === "join" && roomPreview && joinStep === 0) {
-      setJoinStep(1);
-    }
+    if (stage === "join" && roomPreview && joinStep === 0) setJoinStep(1);
   }, [joinStep, roomPreview, stage]);
 
   useEffect(() => {
-    if (!preferredSeatId) {
-      return;
-    }
-
-    if (!roomPreview || !openSeats.some((seat) => seat.seatId === preferredSeatId)) {
-      setPreferredSeatId(undefined);
-    }
+    if (!preferredSeatId) return;
+    if (!roomPreview || !openSeats.some((s) => s.seatId === preferredSeatId)) setPreferredSeatId(undefined);
   }, [openSeats, preferredSeatId, roomPreview]);
 
-  function getStepStatus(index: number, currentStep: SetupFlowStep): SetupStep["status"] {
-    if (index < currentStep) {
-      return "complete";
-    }
-
-    if (index === currentStep) {
-      return "current";
-    }
-
-    return "upcoming";
-  }
-
-  const title =
-    stage === "gateway" ? "Online" : stage === "create" ? "Start game" : "Join room";
-  const subtitle =
-    stage === "gateway"
-      ? "Host a room or board by code."
-      : stage === "create"
-        ? "Seat the crew, pick the board, and send the room code."
-        : "Punch in the code, claim a seat, and board before departure.";
-  const backLabel = stage === "gateway" ? "Back" : "Back";
-  const showBanner =
-    Boolean(error) || (stage === "join" && (reconnectState === "attempting-reconnect" || reconnectState === "reconnect-failed"));
-  const selectedConfig = releasedConfigs.find((config) => config.configId === configId);
-  const previewConfig =
-    roomPreview
-      ? { configId: roomPreview.configId, version: roomPreview.configVersion, mapName: roomPreview.mapName, summary: "" }
-      : null;
-  const railSteps: SetupStep[] =
-    stage === "gateway"
-      ? [
-          { label: "Choose line", meta: "Host or guest", status: "current" as const },
-          { label: "Start game", meta: "Build the room", status: "upcoming" as const },
-          { label: "Join room", meta: "Enter by code", status: "upcoming" as const }
-        ]
-      : stage === "create"
-        ? [
-            { label: "Host", meta: "Who is starting", status: getStepStatus(0, createStep) },
-            { label: "Seats", meta: "Players and bots", status: getStepStatus(1, createStep) },
-          { label: "Map", meta: "Choose board", status: getStepStatus(2, createStep) },
-          { label: "Timer", meta: "Launch check", status: getStepStatus(3, createStep) }
-          ]
-        : [
-            { label: "Room code", meta: "Preview first", status: getStepStatus(0, joinStep) },
-            { label: "Seat", meta: "Open human seat", status: getStepStatus(1, joinStep) },
-            { label: "Enter room", meta: "Name and join", status: getStepStatus(2, joinStep) }
-          ];
-
-  function returnToGateway(): void {
+  function returnToGateway() {
     setStage("gateway");
     setCreateStep(0);
     setJoinStep(0);
@@ -190,83 +102,54 @@ export function MultiplayerSetupScreen({
     onClearRoomPreview?.();
   }
 
-  function chooseStage(nextStage: OnlineSetupStage): void {
-    if (nextStage === "create") {
-      onClearRoomPreview?.();
-      setCreateStep(0);
-      setStage("create");
-      return;
-    }
-    if (nextStage === "join") {
-      setStage("join");
-      setJoinStep(roomPreview ? 1 : 0);
-    }
+  function chooseStage(nextStage: OnlineSetupStage) {
+    if (nextStage === "create") { onClearRoomPreview?.(); setCreateStep(0); setStage("create"); return; }
+    if (nextStage === "join") { setStage("join"); setJoinStep(roomPreview ? 1 : 0); }
   }
 
-  const modeSwitch =
-    stage === "gateway" ? null : (
-      <ModeSwitch
-        value={stage}
-        options={[
-          { value: "create", label: "Start game" },
-          { value: "join", label: "Join room" }
-        ]}
-        onChange={chooseStage}
-      />
-    );
+  function handleChangeJoinRoomCode(code: string) {
+    setJoinRoomCode(code.toUpperCase());
+    setPreferredSeatId(undefined);
+    onClearRoomPreview?.();
+  }
 
-  const createPreflight = (
-    <div className="setup-preflight-card">
-      <span className="setup-preflight-card__eyebrow">{createStep >= 3 ? "Table preflight" : "Table ticket"}</span>
-      {createStep >= 2 ? (
-        <MapThumbnail
-          configId={selectedConfig?.configId ?? configId}
-          mapName={selectedConfig?.mapName ?? "Hudson Hustle"}
-          version={selectedConfig?.version}
-        />
-      ) : (
-        <SetupTicketSlip
-          className="setup-room-code-plate--table"
-          ariaLabel="Table setup ticket"
-          label={createStep === 0 ? "Host" : "Seats"}
-          value={createStep === 0 ? hostName.trim() || "Host" : `${Math.max(1, playerCount - plannedBotCount)} human`}
-          detail={createStep >= 1 ? `${plannedBotCount} bot` : undefined}
-        />
-      )}
-      {createStep >= 1 ? (
-        <div className="setup-summary-stack">
-          <SetupSummaryRow label="Host" value={hostName.trim() || "Host"} />
-          {createStep >= 2 ? (
-            <SetupSummaryRow label="Seats" value={`${Math.max(1, playerCount - plannedBotCount)} human`} detail={`${plannedBotCount} bot`} />
-          ) : null}
-          {createStep >= 3 ? (
-            <>
-              <SetupSummaryRow label="Map" value={selectedConfig?.mapName ?? "Map"} />
-              <SetupSummaryRow label="Timer" value={turnTimeLimitSeconds === 0 ? "Untimed" : `${turnTimeLimitSeconds}s`} />
-            </>
-          ) : null}
-        </div>
-      ) : null}
-    </div>
-  );
+  const showBanner =
+    Boolean(error) || (stage === "join" && (reconnectState === "attempting-reconnect" || reconnectState === "reconnect-failed"));
+  const bannerTone = error || reconnectState === "reconnect-failed" ? "danger" : reconnectState === "attempting-reconnect" ? "waiting" : "neutral";
+  const bannerEyebrow = error || reconnectState === "reconnect-failed" ? "Connection issue" : reconnectState === "attempting-reconnect" ? "Reconnect" : "Separate-device multiplayer";
+  const bannerHeadline =
+    error || reconnectState === "reconnect-failed" ? "Multiplayer setup needs attention." :
+    reconnectState === "attempting-reconnect" ? "Attempting to restore your room." : "Create a room or join a table.";
+  const bannerCopy =
+    error ? error :
+    reconnectState === "reconnect-failed" ? "Saved room recovery failed. Enter the room code again to board." :
+    reconnectState === "attempting-reconnect" ? "Checking the saved room session first." : "Host a table or join one by room code.";
 
-  const joinPreflight = (
-    <div className="setup-preflight-card">
-      <span className="setup-preflight-card__eyebrow">{roomPreview ? "Room board" : "Room ticket"}</span>
-      {previewConfig ? (
-        <MapThumbnail configId={previewConfig.configId} mapName={previewConfig.mapName} version={previewConfig.version} />
-      ) : (
-        <SetupTicketSlip ariaLabel="No room preview yet" label="Room" value={joinRoomCode || "------"} />
-      )}
-      {joinStep > 0 || roomPreview ? (
-        <div className="setup-summary-stack">
-          <SetupSummaryRow label="Room" value={joinRoomCode || "------"} />
-          {roomPreview ? <SetupSummaryRow label="Status" value={`${openSeats.length} open`} /> : null}
-          {joinStep >= 2 ? <SetupSummaryRow label="Seat" value={preferredSeatId ?? "Pick one"} /> : null}
-        </div>
-      ) : null}
-    </div>
-  );
+  const title = stage === "gateway" ? "Online" : stage === "create" ? "Start game" : "Join room";
+  const subtitle =
+    stage === "gateway" ? "Host a room or board by code." :
+    stage === "create" ? "Seat the crew, pick the board, and send the room code." :
+    "Punch in the code, claim a seat, and board before departure.";
+
+  const railSteps: SetupStep[] =
+    stage === "gateway"
+      ? [
+          { label: "Choose line", meta: "Host or guest", status: "current" },
+          { label: "Start game", meta: "Build the room", status: "upcoming" },
+          { label: "Join room", meta: "Enter by code", status: "upcoming" }
+        ]
+      : stage === "create"
+        ? [
+            { label: "Host", meta: "Who is starting", status: getStepStatus(0, createStep) },
+            { label: "Seats", meta: "Players and bots", status: getStepStatus(1, createStep) },
+            { label: "Map", meta: "Choose board", status: getStepStatus(2, createStep) },
+            { label: "Timer", meta: "Launch check", status: getStepStatus(3, createStep) }
+          ]
+        : [
+            { label: "Room code", meta: "Preview first", status: getStepStatus(0, joinStep) },
+            { label: "Seat", meta: "Open human seat", status: getStepStatus(1, joinStep) },
+            { label: "Enter room", meta: "Name and join", status: getStepStatus(2, joinStep) }
+          ];
 
   return (
     <SetupShell
@@ -275,315 +158,99 @@ export function MultiplayerSetupScreen({
       lead={subtitle}
       backgroundImageUrl={setupHeroImageUrl}
       steps={railSteps}
-      modeSwitch={modeSwitch}
+      modeSwitch={
+        stage === "gateway" ? null : (
+          <ModeSwitch
+            value={stage}
+            options={[
+              { value: "create", label: "Start game" },
+              { value: "join", label: "Join room" }
+            ]}
+            onChange={chooseStage}
+          />
+        )
+      }
       backAction={
         stage === "gateway"
-          ? onBack
-            ? <SetupBackButton onClick={onBack}>{backLabel}</SetupBackButton>
-            : null
-          : <SetupBackButton onClick={returnToGateway}>{backLabel}</SetupBackButton>
+          ? onBack ? <SetupBackButton onClick={onBack}>Back</SetupBackButton> : null
+          : <SetupBackButton onClick={returnToGateway}>Back</SetupBackButton>
       }
-      preflight={stage === "create" ? createPreflight : stage === "join" ? joinPreflight : undefined}
+      preflight={
+        stage === "create" ? (
+          <CreateRoomPreflight
+            step={createStep}
+            hostName={hostName}
+            playerCount={playerCount}
+            plannedBotCount={plannedBotCount}
+            turnTimeLimitSeconds={turnTimeLimitSeconds}
+            selectedConfig={selectedConfig}
+            configId={configId}
+          />
+        ) : stage === "join" ? (
+          <JoinRoomPreflight
+            step={joinStep}
+            joinRoomCode={joinRoomCode}
+            roomPreview={roomPreview}
+            openSeatCount={openSeats.length}
+            preferredSeatId={preferredSeatId}
+          />
+        ) : undefined
+      }
     >
       {showBanner ? (
         <div className="setup-counter__status">
-          <StateSurface
-            tone={setupBannerTone}
-            eyebrow={setupBannerEyebrow}
-            headline={setupBannerHeadline}
-            copy={setupBannerCopy}
-          />
+          <StateSurface tone={bannerTone} eyebrow={bannerEyebrow} headline={bannerHeadline} copy={bannerCopy} />
         </div>
       ) : null}
 
       {stage === "gateway" ? (
-        <div className="setup-entry-grid setup-entry-grid--artifacts" data-testid="online-mode-gateway">
-          <DepartureBoardTile
-            onClick={() => {
-              onClearRoomPreview?.();
-              setCreateStep(0);
-              setStage("create");
-            }}
-            testId="online-start-game"
-            ariaLabel="Start an online room"
-            kicker="Host flow"
-            code="START_"
-            copy="Seat the table, pick the board, then share the code."
-            status="Room board"
-          />
-          <DepartureBoardTile
-            onClick={() => {
-              setJoinStep(roomPreview ? 1 : 0);
-              setStage("join");
-            }}
-            testId="online-join-room"
-            ariaLabel="Join an online room"
-            kicker="Guest flow"
-            code="JOIN__"
-            copy="Preview the table, claim a seat, and board."
-            status="Code ticket"
-          />
-        </div>
+        <OnlineGateway
+          onStartGame={() => chooseStage("create")}
+          onJoinRoom={() => chooseStage("join")}
+        />
       ) : null}
 
       {stage === "create" ? (
-        <div className="setup-flow-grid setup-flow-grid--create" data-testid="create-room-panel">
-          {createStep === 0 ? (
-            <SetupStepPanel
-              eyebrow="Now"
-              title="Host"
-              meta="Name the room captain"
-              actions={
-                <SetupActions>
-                  <Button variant="primary" onClick={() => setCreateStep(1)}>
-                    Seat table
-                  </Button>
-                </SetupActions>
-              }
-            >
-              <div className="setup-field-grid">
-                <FormField label="Your name">
-                  <input value={hostName} maxLength={24} onChange={(event) => setHostName(event.target.value)} />
-                </FormField>
-              </div>
-            </SetupStepPanel>
-          ) : null}
-
-          {createStep === 1 ? (
-            <SetupStepPanel
-              eyebrow="Now"
-              title="Seats"
-              meta={`${plannedBotCount} bot · ${plannedHumanOpenSeats} human open`}
-              actions={
-                <SetupActions>
-                  <Button onClick={() => setCreateStep(0)}>Back</Button>
-                  <Button variant="primary" onClick={() => setCreateStep(2)}>
-                    Pick board
-                  </Button>
-                </SetupActions>
-              }
-            >
-              <div className="setup-field-grid">
-                <FormField label="Players">
-                  <select value={playerCount} onChange={(event) => setPlayerCount(Number(event.target.value) as 2 | 3 | 4)}>
-                    <option value={2}>2 players</option>
-                    <option value={3}>3 players</option>
-                    <option value={4}>4 players</option>
-                  </select>
-                </FormField>
-              </div>
-
-              <SeatPlan
-                seats={setupSeatIds.map((seatId, index): SeatRow => {
-                  const isHostSeat = seatId === "seat-1";
-                  const isBotSeat = botSeatIds.includes(seatId);
-                  return {
-                    id: seatId,
-                    title: seatId,
-                    meta: isHostSeat ? "Host seat" : isBotSeat ? `Bot ${index}` : "Open human seat",
-                    isBot: isBotSeat,
-                    testId: `seat-plan-${seatId}`,
-                    action: isHostSeat ? (
-                      <TokenButton label="Host" tone="host" className="seat-plan__toggle seat-plan__toggle--fixed" />
-                    ) : (
-                      <TokenButton
-                        label={isBotSeat ? "Bot" : "Open"}
-                        tone={isBotSeat ? "bot" : "open"}
-                        selected={isBotSeat}
-                        className="seat-plan__toggle"
-                        testId={`seat-plan-toggle-${seatId}`}
-                        onClick={() =>
-                          setBotSeatIds((current) =>
-                            current.includes(seatId) ? current.filter((entry) => entry !== seatId) : [...current, seatId]
-                          )
-                        }
-                      />
-                    )
-                  };
-                })}
-              />
-
-            </SetupStepPanel>
-          ) : null}
-
-          {createStep === 2 ? (
-            <SetupStepPanel
-              eyebrow="Now"
-              title="Map"
-              meta="Choose the board"
-              actions={
-                <SetupActions>
-                  <Button onClick={() => setCreateStep(1)}>Back</Button>
-                  <Button variant="primary" onClick={() => setCreateStep(3)}>
-                    Set timer
-                  </Button>
-                </SetupActions>
-              }
-            >
-              <div className="setup-board-preflight">
-                <MapThumbnail
-                  configId={selectedConfig?.configId ?? configId}
-                  mapName={selectedConfig?.mapName ?? "Hudson Hustle"}
-                  version={selectedConfig?.version}
-                />
-                <div className="setup-board-preflight__controls">
-                  <FormField label="Map">
-                    <select value={configId} onChange={(event) => setConfigId(event.target.value)}>
-                      {releasedConfigs.map((config) => (
-                        <option key={config.configId} value={config.configId}>
-                          {config.version} · {config.mapName}
-                        </option>
-                      ))}
-                    </select>
-                  </FormField>
-                  {selectedConfig ? (
-                    <p className="map-picker-meta">
-                      {/* ~0.6 min per route + 20 min base from playtesting */}
-                      {selectedConfig.cityCount} stations · {selectedConfig.routeCount} routes · ~{Math.round(selectedConfig.routeCount * 0.6 + 20)} min
-                    </p>
-                  ) : null}
-                </div>
-              </div>
-            </SetupStepPanel>
-          ) : null}
-
-          {createStep === 3 ? (
-            <SetupStepPanel
-              eyebrow="Now"
-              title="Timer"
-              meta="Set the pace and launch"
-              actions={
-                <SetupActions>
-                  <Button onClick={() => setCreateStep(2)}>Back</Button>
-                  <Button
-                    variant="primary"
-                    disabled={isCreatingRoom}
-                    onClick={() =>
-                      onCreateRoom({
-                        hostName: hostName.trim() || "Host",
-                        playerCount,
-                        configId,
-                        turnTimeLimitSeconds,
-                        botSeatIds: botSeatIds.filter((seatId) => setupSeatIds.includes(seatId))
-                      })
-                    }
-                  >
-                    {isCreatingRoom ? "Creating room..." : "Create room"}
-                  </Button>
-                </SetupActions>
-              }
-            >
-              <div className="setup-timer-preflight">
-                <FormField as="div" label="Timer" className="form-field--timer" helper="Enter seconds. 0 = untimed · 30 = 30 s · 60 = 1 min.">
-                  <TimerPicker value={turnTimeLimitSeconds} onChange={setTurnTimeLimitSeconds} />
-                </FormField>
-              </div>
-            </SetupStepPanel>
-          ) : null}
-        </div>
+        <CreateRoomFlow
+          step={createStep}
+          releasedConfigs={releasedConfigs}
+          isCreatingRoom={isCreatingRoom}
+          hostName={hostName}
+          playerCount={playerCount}
+          configId={configId}
+          turnTimeLimitSeconds={turnTimeLimitSeconds}
+          botSeatIds={botSeatIds}
+          setupSeatIds={setupSeatIds}
+          plannedBotCount={plannedBotCount}
+          plannedHumanOpenSeats={plannedHumanOpenSeats}
+          selectedConfig={selectedConfig}
+          onChangeStep={setCreateStep}
+          onChangeHostName={setHostName}
+          onChangePlayerCount={setPlayerCount}
+          onChangeConfigId={setConfigId}
+          onChangeTurnTimeLimit={setTurnTimeLimitSeconds}
+          onToggleBotSeat={(seatId) =>
+            setBotSeatIds((curr) => curr.includes(seatId) ? curr.filter((id) => id !== seatId) : [...curr, seatId])
+          }
+          onCreateRoom={onCreateRoom}
+        />
       ) : null}
 
       {stage === "join" ? (
-        <div className="setup-flow-grid setup-flow-grid--join" data-testid="join-room-panel">
-          {joinStep === 0 ? (
-            <SetupStepPanel eyebrow="Now" title="Room code" meta="Check the table before choosing a seat">
-              <div className="setup-field-grid setup-field-grid--launch">
-                <FormField label="Room code" helper={`${ROOM_CODE_LENGTH}-character code`}>
-                  <input
-                    value={joinRoomCode}
-                    onChange={(event) => {
-                      setJoinRoomCode(event.target.value.toUpperCase());
-                      setPreferredSeatId(undefined);
-                      onClearRoomPreview?.();
-                    }}
-                    maxLength={ROOM_CODE_LENGTH}
-                    placeholder="------"
-                  />
-                </FormField>
-                <Button
-                  className="join-preview-button"
-                  disabled={joinRoomCode.length < ROOM_CODE_LENGTH}
-                  onClick={() => onPreviewRoom(joinRoomCode)}
-                >
-                  Preview
-                </Button>
-              </div>
-              {roomPreview ? (
-                <div className="room-preview room-preview--ticket">
-                  <MapThumbnail configId={roomPreview.configId} mapName={roomPreview.mapName} version={roomPreview.configVersion} />
-                  <p className="muted-copy">
-                    {roomPreview.turnTimeLimitSeconds === 0 ? "Untimed" : `${roomPreview.turnTimeLimitSeconds}s`} · {openSeats.length} open
-                  </p>
-                </div>
-              ) : null}
-            </SetupStepPanel>
-          ) : null}
-
-          {joinStep === 1 ? (
-            <SetupStepPanel
-              eyebrow="Now"
-              title="Seat"
-              meta={roomPreview ? `${openSeats.length} open` : "Preview a room to reveal seats."}
-              actions={
-                <SetupActions>
-                  <Button onClick={() => setJoinStep(0)}>Back</Button>
-                  <Button
-                    variant="primary"
-                    disabled={!roomPreview || !preferredSeatId || !openSeats.some((seat) => seat.seatId === preferredSeatId)}
-                    onClick={() => setJoinStep(2)}
-                  >
-                    Enter table
-                  </Button>
-                </SetupActions>
-              }
-            >
-              {roomPreview ? (
-                <div className="seat-choice-row">
-                  {openSeats.map((seat) => (
-                    <TokenButton
-                      key={seat.seatId}
-                      label={seat.seatId}
-                      tone="open"
-                      selected={preferredSeatId === seat.seatId}
-                      onClick={() => setPreferredSeatId(seat.seatId)}
-                    />
-                  ))}
-                </div>
-              ) : null}
-              {roomPreview && openSeats.length === 0 ? <p className="muted-copy room-preview__empty">No open human seats left in this room.</p> : null}
-            </SetupStepPanel>
-          ) : null}
-
-          {joinStep === 2 ? (
-            <SetupStepPanel
-              eyebrow="Now"
-              title="Enter room"
-              meta="Name the seat and enter"
-              actions={
-                <SetupActions>
-                  <Button onClick={() => setJoinStep(1)}>Back</Button>
-                  <Button
-                    variant="primary"
-                    onClick={() =>
-                      onJoinRoom({
-                        roomCode: joinRoomCode,
-                        playerName: joinPlayerName.trim() || "Player",
-                        preferredSeatId
-                      })
-                    }
-                  >
-                    Join room
-                  </Button>
-                </SetupActions>
-              }
-            >
-              <FormField label="Your name">
-                <input value={joinPlayerName} maxLength={24} onChange={(event) => setJoinPlayerName(event.target.value)} />
-              </FormField>
-
-            </SetupStepPanel>
-          ) : null}
-        </div>
+        <JoinRoomFlow
+          step={joinStep}
+          roomPreview={roomPreview}
+          openSeats={openSeats}
+          joinRoomCode={joinRoomCode}
+          joinPlayerName={joinPlayerName}
+          preferredSeatId={preferredSeatId}
+          onChangeStep={setJoinStep}
+          onChangeJoinRoomCode={handleChangeJoinRoomCode}
+          onChangeJoinPlayerName={setJoinPlayerName}
+          onChangePreferredSeatId={setPreferredSeatId}
+          onPreviewRoom={onPreviewRoom}
+          onJoinRoom={onJoinRoom}
+        />
       ) : null}
     </SetupShell>
   );

--- a/apps/web/src/components/multiplayer/CreateRoomFlow.tsx
+++ b/apps/web/src/components/multiplayer/CreateRoomFlow.tsx
@@ -1,0 +1,202 @@
+import type { HudsonHustleReleasedConfigSummary } from "@hudson-hustle/game-data";
+import { FormField } from "../system/FormField";
+import { Button } from "../system/Button";
+import { TimerPicker } from "../system/TimerPicker";
+import {
+  MapThumbnail,
+  SeatPlan,
+  SetupActions,
+  SetupStepPanel,
+  TokenButton,
+  type SeatRow
+} from "../setup";
+import type { CreateRoomForm, SetupFlowStep } from "./multiplayerSetup.types";
+
+interface CreateRoomFlowProps {
+  step: SetupFlowStep;
+  releasedConfigs: HudsonHustleReleasedConfigSummary[];
+  isCreatingRoom: boolean;
+  hostName: string;
+  playerCount: 2 | 3 | 4;
+  configId: string;
+  turnTimeLimitSeconds: number;
+  botSeatIds: string[];
+  setupSeatIds: string[];
+  plannedBotCount: number;
+  plannedHumanOpenSeats: number;
+  selectedConfig: HudsonHustleReleasedConfigSummary | undefined;
+  onChangeStep: (step: SetupFlowStep) => void;
+  onChangeHostName: (v: string) => void;
+  onChangePlayerCount: (v: 2 | 3 | 4) => void;
+  onChangeConfigId: (v: string) => void;
+  onChangeTurnTimeLimit: (v: number) => void;
+  onToggleBotSeat: (seatId: string) => void;
+  onCreateRoom: (form: CreateRoomForm) => void;
+}
+
+export function CreateRoomFlow({
+  step,
+  releasedConfigs,
+  isCreatingRoom,
+  hostName,
+  playerCount,
+  configId,
+  turnTimeLimitSeconds,
+  botSeatIds,
+  setupSeatIds,
+  plannedBotCount,
+  plannedHumanOpenSeats,
+  selectedConfig,
+  onChangeStep,
+  onChangeHostName,
+  onChangePlayerCount,
+  onChangeConfigId,
+  onChangeTurnTimeLimit,
+  onToggleBotSeat,
+  onCreateRoom
+}: CreateRoomFlowProps): JSX.Element {
+  return (
+    <div className="setup-flow-grid setup-flow-grid--create" data-testid="create-room-panel">
+      {step === 0 ? (
+        <SetupStepPanel
+          eyebrow="Now"
+          title="Host"
+          meta="Name the room captain"
+          actions={
+            <SetupActions>
+              <Button variant="primary" onClick={() => onChangeStep(1)}>Seat table</Button>
+            </SetupActions>
+          }
+        >
+          <div className="setup-field-grid">
+            <FormField label="Your name">
+              <input value={hostName} maxLength={24} onChange={(e) => onChangeHostName(e.target.value)} />
+            </FormField>
+          </div>
+        </SetupStepPanel>
+      ) : null}
+
+      {step === 1 ? (
+        <SetupStepPanel
+          eyebrow="Now"
+          title="Seats"
+          meta={`${plannedBotCount} bot · ${plannedHumanOpenSeats} human open`}
+          actions={
+            <SetupActions>
+              <Button onClick={() => onChangeStep(0)}>Back</Button>
+              <Button variant="primary" onClick={() => onChangeStep(2)}>Pick board</Button>
+            </SetupActions>
+          }
+        >
+          <div className="setup-field-grid">
+            <FormField label="Players">
+              <select value={playerCount} onChange={(e) => onChangePlayerCount(Number(e.target.value) as 2 | 3 | 4)}>
+                <option value={2}>2 players</option>
+                <option value={3}>3 players</option>
+                <option value={4}>4 players</option>
+              </select>
+            </FormField>
+          </div>
+          <SeatPlan
+            seats={setupSeatIds.map((seatId, index): SeatRow => {
+              const isHostSeat = seatId === "seat-1";
+              const isBotSeat = botSeatIds.includes(seatId);
+              return {
+                id: seatId,
+                title: seatId,
+                meta: isHostSeat ? "Host seat" : isBotSeat ? `Bot ${index}` : "Open human seat",
+                isBot: isBotSeat,
+                testId: `seat-plan-${seatId}`,
+                action: isHostSeat ? (
+                  <TokenButton label="Host" tone="host" className="seat-plan__toggle seat-plan__toggle--fixed" />
+                ) : (
+                  <TokenButton
+                    label={isBotSeat ? "Bot" : "Open"}
+                    tone={isBotSeat ? "bot" : "open"}
+                    selected={isBotSeat}
+                    className="seat-plan__toggle"
+                    testId={`seat-plan-toggle-${seatId}`}
+                    onClick={() => onToggleBotSeat(seatId)}
+                  />
+                )
+              };
+            })}
+          />
+        </SetupStepPanel>
+      ) : null}
+
+      {step === 2 ? (
+        <SetupStepPanel
+          eyebrow="Now"
+          title="Map"
+          meta="Choose the board"
+          actions={
+            <SetupActions>
+              <Button onClick={() => onChangeStep(1)}>Back</Button>
+              <Button variant="primary" onClick={() => onChangeStep(3)}>Set timer</Button>
+            </SetupActions>
+          }
+        >
+          <div className="setup-board-preflight">
+            <MapThumbnail
+              configId={selectedConfig?.configId ?? configId}
+              mapName={selectedConfig?.mapName ?? "Hudson Hustle"}
+              version={selectedConfig?.version}
+            />
+            <div className="setup-board-preflight__controls">
+              <FormField label="Map">
+                <select value={configId} onChange={(e) => onChangeConfigId(e.target.value)}>
+                  {releasedConfigs.map((config) => (
+                    <option key={config.configId} value={config.configId}>
+                      {config.version} · {config.mapName}
+                    </option>
+                  ))}
+                </select>
+              </FormField>
+              {selectedConfig ? (
+                <p className="map-picker-meta">
+                  {/* ~0.6 min per route + 20 min base from playtesting */}
+                  {selectedConfig.cityCount} stations · {selectedConfig.routeCount} routes · ~{Math.round(selectedConfig.routeCount * 0.6 + 20)} min
+                </p>
+              ) : null}
+            </div>
+          </div>
+        </SetupStepPanel>
+      ) : null}
+
+      {step === 3 ? (
+        <SetupStepPanel
+          eyebrow="Now"
+          title="Timer"
+          meta="Set the pace and launch"
+          actions={
+            <SetupActions>
+              <Button onClick={() => onChangeStep(2)}>Back</Button>
+              <Button
+                variant="primary"
+                disabled={isCreatingRoom}
+                onClick={() =>
+                  onCreateRoom({
+                    hostName: hostName.trim() || "Host",
+                    playerCount,
+                    configId,
+                    turnTimeLimitSeconds,
+                    botSeatIds: botSeatIds.filter((seatId) => setupSeatIds.includes(seatId))
+                  })
+                }
+              >
+                {isCreatingRoom ? "Creating room..." : "Create room"}
+              </Button>
+            </SetupActions>
+          }
+        >
+          <div className="setup-timer-preflight">
+            <FormField as="div" label="Timer" className="form-field--timer" helper="Enter seconds. 0 = untimed · 30 = 30 s · 60 = 1 min.">
+              <TimerPicker value={turnTimeLimitSeconds} onChange={onChangeTurnTimeLimit} />
+            </FormField>
+          </div>
+        </SetupStepPanel>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/multiplayer/CreateRoomPreflight.tsx
+++ b/apps/web/src/components/multiplayer/CreateRoomPreflight.tsx
@@ -1,0 +1,62 @@
+import type { HudsonHustleReleasedConfigSummary } from "@hudson-hustle/game-data";
+import { MapThumbnail, SetupSummaryRow, SetupTicketSlip } from "../setup";
+import type { SetupFlowStep } from "./multiplayerSetup.types";
+
+interface CreateRoomPreflightProps {
+  step: SetupFlowStep;
+  hostName: string;
+  playerCount: number;
+  plannedBotCount: number;
+  turnTimeLimitSeconds: number;
+  selectedConfig: HudsonHustleReleasedConfigSummary | undefined;
+  configId: string;
+}
+
+export function CreateRoomPreflight({
+  step,
+  hostName,
+  playerCount,
+  plannedBotCount,
+  turnTimeLimitSeconds,
+  selectedConfig,
+  configId
+}: CreateRoomPreflightProps): JSX.Element {
+  return (
+    <div className="setup-preflight-card">
+      <span className="setup-preflight-card__eyebrow">{step >= 3 ? "Table preflight" : "Table ticket"}</span>
+      {step >= 2 ? (
+        <MapThumbnail
+          configId={selectedConfig?.configId ?? configId}
+          mapName={selectedConfig?.mapName ?? "Hudson Hustle"}
+          version={selectedConfig?.version}
+        />
+      ) : (
+        <SetupTicketSlip
+          className="setup-room-code-plate--table"
+          ariaLabel="Table setup ticket"
+          label={step === 0 ? "Host" : "Seats"}
+          value={step === 0 ? hostName.trim() || "Host" : `${Math.max(1, playerCount - plannedBotCount)} human`}
+          detail={step >= 1 ? `${plannedBotCount} bot` : undefined}
+        />
+      )}
+      {step >= 1 ? (
+        <div className="setup-summary-stack">
+          <SetupSummaryRow label="Host" value={hostName.trim() || "Host"} />
+          {step >= 2 ? (
+            <SetupSummaryRow
+              label="Seats"
+              value={`${Math.max(1, playerCount - plannedBotCount)} human`}
+              detail={`${plannedBotCount} bot`}
+            />
+          ) : null}
+          {step >= 3 ? (
+            <>
+              <SetupSummaryRow label="Map" value={selectedConfig?.mapName ?? "Map"} />
+              <SetupSummaryRow label="Timer" value={turnTimeLimitSeconds === 0 ? "Untimed" : `${turnTimeLimitSeconds}s`} />
+            </>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/multiplayer/JoinRoomFlow.tsx
+++ b/apps/web/src/components/multiplayer/JoinRoomFlow.tsx
@@ -1,0 +1,142 @@
+import type { RoomSummary } from "@hudson-hustle/game-core";
+import { FormField } from "../system/FormField";
+import { Button } from "../system/Button";
+import { MapThumbnail, SetupActions, SetupStepPanel, TokenButton } from "../setup";
+import type { SetupFlowStep } from "./multiplayerSetup.types";
+
+const ROOM_CODE_LENGTH = 6;
+
+interface OpenSeat {
+  seatId: string;
+  playerName: string | null;
+}
+
+interface JoinRoomFlowProps {
+  step: SetupFlowStep;
+  roomPreview: RoomSummary | null;
+  openSeats: OpenSeat[];
+  joinRoomCode: string;
+  joinPlayerName: string;
+  preferredSeatId: string | undefined;
+  onChangeStep: (step: SetupFlowStep) => void;
+  onChangeJoinRoomCode: (v: string) => void;
+  onChangeJoinPlayerName: (v: string) => void;
+  onChangePreferredSeatId: (v: string | undefined) => void;
+  onPreviewRoom: (code: string) => void;
+  onJoinRoom: (form: { roomCode: string; playerName: string; preferredSeatId?: string }) => void;
+}
+
+export function JoinRoomFlow({
+  step,
+  roomPreview,
+  openSeats,
+  joinRoomCode,
+  joinPlayerName,
+  preferredSeatId,
+  onChangeStep,
+  onChangeJoinRoomCode,
+  onChangeJoinPlayerName,
+  onChangePreferredSeatId,
+  onPreviewRoom,
+  onJoinRoom
+}: JoinRoomFlowProps): JSX.Element {
+  return (
+    <div className="setup-flow-grid setup-flow-grid--join" data-testid="join-room-panel">
+      {step === 0 ? (
+        <SetupStepPanel eyebrow="Now" title="Room code" meta="Check the table before choosing a seat">
+          <div className="setup-field-grid setup-field-grid--launch">
+            <FormField label="Room code" helper={`${ROOM_CODE_LENGTH}-character code`}>
+              <input
+                value={joinRoomCode}
+                onChange={(e) => onChangeJoinRoomCode(e.target.value)}
+                maxLength={ROOM_CODE_LENGTH}
+                placeholder="------"
+              />
+            </FormField>
+            <Button
+              className="join-preview-button"
+              disabled={joinRoomCode.length < ROOM_CODE_LENGTH}
+              onClick={() => onPreviewRoom(joinRoomCode)}
+            >
+              Preview
+            </Button>
+          </div>
+          {roomPreview ? (
+            <div className="room-preview room-preview--ticket">
+              <MapThumbnail configId={roomPreview.configId} mapName={roomPreview.mapName} version={roomPreview.configVersion} />
+              <p className="muted-copy">
+                {roomPreview.turnTimeLimitSeconds === 0 ? "Untimed" : `${roomPreview.turnTimeLimitSeconds}s`} · {openSeats.length} open
+              </p>
+            </div>
+          ) : null}
+        </SetupStepPanel>
+      ) : null}
+
+      {step === 1 ? (
+        <SetupStepPanel
+          eyebrow="Now"
+          title="Seat"
+          meta={roomPreview ? `${openSeats.length} open` : "Preview a room to reveal seats."}
+          actions={
+            <SetupActions>
+              <Button onClick={() => onChangeStep(0)}>Back</Button>
+              <Button
+                variant="primary"
+                disabled={!roomPreview || !preferredSeatId || !openSeats.some((s) => s.seatId === preferredSeatId)}
+                onClick={() => onChangeStep(2)}
+              >
+                Enter table
+              </Button>
+            </SetupActions>
+          }
+        >
+          {roomPreview ? (
+            <div className="seat-choice-row">
+              {openSeats.map((seat) => (
+                <TokenButton
+                  key={seat.seatId}
+                  label={seat.seatId}
+                  tone="open"
+                  selected={preferredSeatId === seat.seatId}
+                  onClick={() => onChangePreferredSeatId(seat.seatId)}
+                />
+              ))}
+            </div>
+          ) : null}
+          {roomPreview && openSeats.length === 0 ? (
+            <p className="muted-copy room-preview__empty">No open human seats left in this room.</p>
+          ) : null}
+        </SetupStepPanel>
+      ) : null}
+
+      {step === 2 ? (
+        <SetupStepPanel
+          eyebrow="Now"
+          title="Enter room"
+          meta="Name the seat and enter"
+          actions={
+            <SetupActions>
+              <Button onClick={() => onChangeStep(1)}>Back</Button>
+              <Button
+                variant="primary"
+                onClick={() =>
+                  onJoinRoom({
+                    roomCode: joinRoomCode,
+                    playerName: joinPlayerName.trim() || "Player",
+                    preferredSeatId
+                  })
+                }
+              >
+                Join room
+              </Button>
+            </SetupActions>
+          }
+        >
+          <FormField label="Your name">
+            <input value={joinPlayerName} maxLength={24} onChange={(e) => onChangeJoinPlayerName(e.target.value)} />
+          </FormField>
+        </SetupStepPanel>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/multiplayer/JoinRoomPreflight.tsx
+++ b/apps/web/src/components/multiplayer/JoinRoomPreflight.tsx
@@ -1,0 +1,41 @@
+import type { RoomSummary } from "@hudson-hustle/game-core";
+import { MapThumbnail, SetupSummaryRow, SetupTicketSlip } from "../setup";
+import type { SetupFlowStep } from "./multiplayerSetup.types";
+
+interface JoinRoomPreflightProps {
+  step: SetupFlowStep;
+  joinRoomCode: string;
+  roomPreview: RoomSummary | null;
+  openSeatCount: number;
+  preferredSeatId: string | undefined;
+}
+
+export function JoinRoomPreflight({
+  step,
+  joinRoomCode,
+  roomPreview,
+  openSeatCount,
+  preferredSeatId
+}: JoinRoomPreflightProps): JSX.Element {
+  const previewConfig = roomPreview
+    ? { configId: roomPreview.configId, mapName: roomPreview.mapName, version: roomPreview.configVersion }
+    : null;
+
+  return (
+    <div className="setup-preflight-card">
+      <span className="setup-preflight-card__eyebrow">{roomPreview ? "Room board" : "Room ticket"}</span>
+      {previewConfig ? (
+        <MapThumbnail configId={previewConfig.configId} mapName={previewConfig.mapName} version={previewConfig.version} />
+      ) : (
+        <SetupTicketSlip ariaLabel="No room preview yet" label="Room" value={joinRoomCode || "------"} />
+      )}
+      {step > 0 || roomPreview ? (
+        <div className="setup-summary-stack">
+          <SetupSummaryRow label="Room" value={joinRoomCode || "------"} />
+          {roomPreview ? <SetupSummaryRow label="Status" value={`${openSeatCount} open`} /> : null}
+          {step >= 2 ? <SetupSummaryRow label="Seat" value={preferredSeatId ?? "Pick one"} /> : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/multiplayer/OnlineGateway.tsx
+++ b/apps/web/src/components/multiplayer/OnlineGateway.tsx
@@ -1,0 +1,31 @@
+import { DepartureBoardTile } from "../setup";
+
+interface OnlineGatewayProps {
+  onStartGame: () => void;
+  onJoinRoom: () => void;
+}
+
+export function OnlineGateway({ onStartGame, onJoinRoom }: OnlineGatewayProps): JSX.Element {
+  return (
+    <div className="setup-entry-grid setup-entry-grid--artifacts" data-testid="online-mode-gateway">
+      <DepartureBoardTile
+        onClick={onStartGame}
+        testId="online-start-game"
+        ariaLabel="Start an online room"
+        kicker="Host flow"
+        code="START_"
+        copy="Seat the table, pick the board, then share the code."
+        status="Room board"
+      />
+      <DepartureBoardTile
+        onClick={onJoinRoom}
+        testId="online-join-room"
+        ariaLabel="Join an online room"
+        kicker="Guest flow"
+        code="JOIN__"
+        copy="Preview the table, claim a seat, and board."
+        status="Code ticket"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/multiplayer/index.ts
+++ b/apps/web/src/components/multiplayer/index.ts
@@ -1,0 +1,6 @@
+export { CreateRoomFlow } from "./CreateRoomFlow";
+export { CreateRoomPreflight } from "./CreateRoomPreflight";
+export { JoinRoomFlow } from "./JoinRoomFlow";
+export { JoinRoomPreflight } from "./JoinRoomPreflight";
+export { OnlineGateway } from "./OnlineGateway";
+export { getStepStatus, type CreateRoomForm, type OnlineSetupStage, type SetupFlowStep } from "./multiplayerSetup.types";

--- a/apps/web/src/components/multiplayer/multiplayerSetup.types.ts
+++ b/apps/web/src/components/multiplayer/multiplayerSetup.types.ts
@@ -1,0 +1,16 @@
+export interface CreateRoomForm {
+  hostName: string;
+  playerCount: 2 | 3 | 4;
+  configId: string;
+  turnTimeLimitSeconds: number;
+  botSeatIds: string[];
+}
+
+export type OnlineSetupStage = "gateway" | "create" | "join";
+export type SetupFlowStep = 0 | 1 | 2 | 3;
+
+export function getStepStatus(index: number, currentStep: SetupFlowStep): "current" | "complete" | "upcoming" {
+  if (index < currentStep) return "complete";
+  if (index === currentStep) return "current";
+  return "upcoming";
+}


### PR DESCRIPTION
## Summary
- Extracts 3 stage views, 2 preflight sidebars, and shared types from `MultiplayerSetupScreen.tsx`
- File drops from **590 → 257 lines** — parent is now state + orchestration only
- Zero behavior changes; form state stays in parent so preflights can read it

## New files
| File | What |
|------|------|
| `multiplayerSetup.types.ts` | `CreateRoomForm`, `OnlineSetupStage`, `SetupFlowStep`, `getStepStatus()` |
| `OnlineGateway` | Gateway DepartureBoardTile cards (Start game / Join room) |
| `CreateRoomFlow` | 4-step create wizard (Host → Seats → Map → Timer), controlled component |
| `JoinRoomFlow` | 3-step join wizard (Room code → Seat → Enter room), controlled component |
| `CreateRoomPreflight` | Sidebar summary card for create stage |
| `JoinRoomPreflight` | Sidebar summary card for join stage |

## Test plan
- [ ] Gateway: Start game → enters create flow; Join room → enters join flow
- [ ] Create flow: all 4 steps advance/go back correctly; room is created at step 3
- [ ] Join flow: room code preview loads; seat picker shows open seats; join submits with correct payload
- [ ] Preflight sidebar updates at each step in both flows
- [ ] Reconnect state: `attempting-reconnect` opens join step 2; `reconnect-failed` opens join step 0
- [ ] Error banner shows on connection errors
- [ ] TypeScript: `pnpm tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)