### PR TITLE
feat(design): D7 motion token audit — system.css already clean

### DIFF
--- a/docs/design-system-third-pass.md
+++ b/docs/design-system-third-pass.md
@@ -112,11 +112,12 @@ Storybook (validate: does running code match Pencil design?)
 **Files:** `system.css`  
 **Tool:** `[Code]`
 
-| [ ] | What |
+| [x] | What |
 |-----|------|
-| [ ] | Tokens exist in `theme.css`: `--duration-fast/base/slow`, `--easing-standard/expressive` |
-| [ ] | Replace remaining hardcoded `ms` values in `system.css` transitions with tokens |
-| [ ] | `game.css` is already clean — skip |
+| [x] | Tokens exist in `theme.css`: `--duration-fast/base/slow`, `--easing-standard/expressive` |
+| [x] | All `system.css` transitions already use motion tokens — no hardcoded `ms` values found |
+| [x] | `game.css` clean — only `0.01ms !important` in `prefers-reduced-motion` override (intentional a11y, not replaced) |
+| [x] | `notification-drift 4.2s` skipped — one-off decorative animation, no standard token maps to it |
 
 ---
 


### PR DESCRIPTION
## Summary

Audit of hardcoded timing values across `system.css` and `game.css`.

**Result: nothing to replace.**

- `system.css` transitions: all 8 transition blocks already use `var(--duration-fast)`, `var(--duration-base)`, and `var(--easing-standard)` — adopted in a prior pass
- `game.css`: only hardcoded timing is `0.01ms !important` inside the `prefers-reduced-motion` media query override — intentional a11y reset, must not be tokenized
- `notification-drift 4.2s`: a one-off long decorative animation with no standard token equivalent — left as-is

Closing D7 and the design-system-third-pass plan.

## Test plan

- [ ] No visual or motion regressions — this is a no-op commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)