### PR TITLE
feat(ui): game board redesign — 5-panel layout, floating overlays, batched notifications

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -202,6 +202,7 @@ export default function App(): JSX.Element {
   const [realtimeStatus, setRealtimeStatus] = useState<RealtimeStatus>("idle");
   const [selectedRouteId, setSelectedRouteId] = useState<string | null>(null);
   const [selectedCityId, setSelectedCityId] = useState<string | null>(null);
+  const [buildAnchor, setBuildAnchor] = useState<{ x: number; y: number } | null>(null);
   const [selectedTicketIds, setSelectedTicketIds] = useState<string[]>([]);
   const [focusedTicket, setFocusedTicket] = useState<TicketDef | null>(null);
   const [pinnedTicket, setPinnedTicket] = useState<TicketDef | null>(null);
@@ -960,21 +961,24 @@ export default function App(): JSX.Element {
                 selectedRouteId={selectedRouteId}
                 selectedCityId={selectedCityId}
                 highlightedCityIds={highlightedCityIds}
-                onSelectRoute={(routeId) => {
+                onSelectRoute={(routeId, position) => {
                   setSelectedRouteId(routeId);
                   setSelectedCityId(null);
                   setPaymentPreview(null);
+                  setBuildAnchor(position ?? null);
                 }}
-                onSelectCity={(cityId) => {
+                onSelectCity={(cityId, position) => {
                   setSelectedCityId(cityId);
                   setSelectedRouteId(null);
                   setPaymentPreview(null);
+                  setBuildAnchor(position ?? null);
                 }}
               />
               {/* Floating build popup */}
               {(currentRoute || currentCity) && publicGame.phase === "main" ? (
                 <FloatingBuildPanel
-                  onClose={() => { setSelectedRouteId(null); setSelectedCityId(null); setPaymentPreview(null); }}
+                  anchor={buildAnchor}
+                  onClose={() => { setSelectedRouteId(null); setSelectedCityId(null); setPaymentPreview(null); setBuildAnchor(null); }}
                 >
                   {currentRoute ? (
                     <SurfaceCard

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -305,7 +305,8 @@ export default function App(): JSX.Element {
     });
 
     socket.on("game:update:public", (game) => {
-      announceGameLog(game);
+      // Notification firing handled by the useEffect on snapshot.game.log.length
+      // (calling announceGameLog here would race with the state update).
       setSnapshot((current) => (current ? { ...current, game } : current));
     });
 
@@ -499,27 +500,6 @@ export default function App(): JSX.Element {
     window.setTimeout(() => {
       setNotifications((current) => current.filter((notification) => notification.id !== id));
     }, 4200);
-  }
-
-  function announceGameLog(game: PublicGameState) {
-    const latestLog = game.log.at(-1);
-    if (!latestLog) {
-      return;
-    }
-
-    if (!lastAnnouncedLogRef.current) {
-      lastAnnouncedLogRef.current = latestLog;
-      lastAnnouncedLogLengthRef.current = game.log.length;
-      return;
-    }
-
-    if (game.log.length <= lastAnnouncedLogLengthRef.current) {
-      return;
-    }
-
-    lastAnnouncedLogRef.current = latestLog;
-    lastAnnouncedLogLengthRef.current = game.log.length;
-    pushNotification(latestLog, game.phase === "gameOver" ? "success" : "neutral");
   }
 
   useEffect(() => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -927,7 +927,7 @@ export default function App(): JSX.Element {
         />
         <div className="topbar-actions">
           <Button className="topbar-icon-btn" aria-label="Guide" onClick={() => setGuideOpen(true)} data-label="Guide">?</Button>
-          <ScoreGuide className="score-guide--subtle topbar-icon-btn" label="★" />
+          <ScoreGuide className="score-guide--subtle topbar-icon-btn" label="★" tooltipLabel="Score" />
           <Button className="topbar-icon-btn topbar-icon-btn--leave" aria-label="Leave room" onClick={() => setShowLeaveConfirm(true)} data-label="Leave">✕</Button>
         </div>
       </header>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1085,7 +1085,7 @@ export default function App(): JSX.Element {
             </div>
           </div>
 
-          {/* Right column: chat + market */}
+          {/* Right column: chat + market — overlaid by ticket picker when active */}
           <div className="right-col" data-tour-target="market">
             <ChatPanel
               messages={chatMessages}
@@ -1101,6 +1101,34 @@ export default function App(): JSX.Element {
               onDrawFromDeck={() => sendGameAction({ type: "draw_card", source: "deck" })}
               className="supply-dock--board"
             />
+            {localPendingTickets.length > 0 ? (
+              <TicketChoiceSheet
+                title={publicGame.phase === "initialTickets" ? "Choose starting tickets" : "Keep new tickets"}
+                subtitle={
+                  publicGame.phase === "initialTickets"
+                    ? "Keep at least two. Ticket choice does not auto-time out in MVP2."
+                    : "Keep at least one. This consumes your turn."
+                }
+                tickets={localPendingTickets}
+                config={mapConfig}
+                minimumKeep={publicGame.phase === "initialTickets" ? 2 : 1}
+                selectedIds={selectedTicketIds}
+                focusedTicketId={focusedTicket?.id ?? null}
+                onFocusTicket={setFocusedTicket}
+                onToggle={(ticketId) =>
+                  setSelectedTicketIds((current) =>
+                    current.includes(ticketId) ? current.filter((id) => id !== ticketId) : [...current, ticketId]
+                  )
+                }
+                onConfirm={() =>
+                  sendGameAction(
+                    publicGame.phase === "initialTickets"
+                      ? { type: "select_initial_tickets", keptTicketIds: selectedTicketIds }
+                      : { type: "keep_drawn_tickets", keptTicketIds: selectedTicketIds }
+                  )
+                }
+              />
+            ) : null}
           </div>
         </main>
       </div>
@@ -1143,35 +1171,6 @@ export default function App(): JSX.Element {
             })}
           </div>
         </GameOverLayer>
-      ) : null}
-
-      {localPendingTickets.length > 0 ? (
-        <TicketChoiceSheet
-          title={publicGame.phase === "initialTickets" ? "Choose starting tickets" : "Keep new tickets"}
-          subtitle={
-            publicGame.phase === "initialTickets"
-              ? "Keep at least two. Ticket choice does not auto-time out in MVP2."
-              : "Keep at least one. This consumes your turn."
-          }
-          tickets={localPendingTickets}
-          config={mapConfig}
-          minimumKeep={publicGame.phase === "initialTickets" ? 2 : 1}
-          selectedIds={selectedTicketIds}
-          focusedTicketId={focusedTicket?.id ?? null}
-          onFocusTicket={setFocusedTicket}
-          onToggle={(ticketId) =>
-            setSelectedTicketIds((current) =>
-              current.includes(ticketId) ? current.filter((id) => id !== ticketId) : [...current, ticketId]
-            )
-          }
-          onConfirm={() =>
-            sendGameAction(
-              publicGame.phase === "initialTickets"
-                ? { type: "select_initial_tickets", keptTicketIds: selectedTicketIds }
-                : { type: "keep_drawn_tickets", keptTicketIds: selectedTicketIds }
-            )
-          }
-        />
       ) : null}
 
       {showLeaveConfirm ? (

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -498,7 +498,7 @@ export default function App(): JSX.Element {
   function pushNotification(message: string, tone: GameplayNotification["tone"] = "neutral") {
     notificationIdRef.current += 1;
     const id = `multi-${Date.now()}-${notificationIdRef.current}`;
-    setNotifications((current) => [...current.slice(-5), { id, message, tone }]);
+    setNotifications((current) => [...current, { id, message, tone }]);
     window.setTimeout(() => {
       setNotifications((current) => current.filter((notification) => notification.id !== id));
     }, 6000);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -35,11 +35,13 @@ import {
 import {
   BoardMap,
   BoardStage,
+  ChatPanel,
   EndgameBreakdown,
+  FloatingBuildPanel,
   FloatingPlayerRoster,
   GameOverLayer,
-  InspectorDock,
   NotificationPipe,
+  PlayerRoster,
   PrivateHandRail,
   ScoreGuide,
   SupplyDock,
@@ -924,21 +926,21 @@ export default function App(): JSX.Element {
           secondsRemaining={liveTimerSecondsRemaining}
         />
         <div className="topbar-actions">
-          <Button onClick={() => setGuideOpen(true)}>Guide</Button>
-          <ScoreGuide className="score-guide--subtle" label="Score" />
-          <Button className="topbar-actions__leave" onClick={() => setShowLeaveConfirm(true)}>
-            Leave room
-          </Button>
+          <Button className="topbar-icon-btn" aria-label="Guide" onClick={() => setGuideOpen(true)} data-label="Guide">?</Button>
+          <ScoreGuide className="score-guide--subtle topbar-icon-btn" label="★" />
+          <Button className="topbar-icon-btn topbar-icon-btn--leave" aria-label="Leave room" onClick={() => setShowLeaveConfirm(true)} data-label="Leave">✕</Button>
         </div>
       </header>
 
       <div className="game-layout">
-        <aside className="side-panel">
-          <div className="side-panel__private-stack">
-            <div data-tour-target="hand">
-              <PrivateHandRail hand={localPlayer.hand} cardPalette={visuals.palettes.cards} paymentPreview={paymentPreview} />
-            </div>
-            <div data-tour-target="tickets">
+        {/* Left column: roster + tickets + draw ticket */}
+        <aside className="side-panel" data-tour-target="roster">
+          <PlayerRoster
+            players={rosterPlayers}
+            activePlayerIndex={snapshot.game.activePlayerIndex}
+            playerPalette={visuals.palettes.players}
+          />
+          <div data-tour-target="tickets">
             <TicketDock
               ticketProgress={ticketProgress}
               config={mapConfig}
@@ -947,170 +949,165 @@ export default function App(): JSX.Element {
               onFocusTicket={setFocusedTicket}
               onTogglePinnedTicket={(ticket) => setPinnedTicket((current) => current?.id === ticket.id ? null : ticket)}
             />
-            </div>
           </div>
+          <Button
+            className="side-panel__draw-ticket"
+            disabled={!canTakeTurnAction}
+            onClick={() => sendGameAction({ type: "draw_tickets" })}
+          >
+            Draw tickets
+          </Button>
         </aside>
 
         <main className="board-column">
-          <BoardStage className="board-panel" isMyTurn={localIsActive && publicGame.phase === "main"}>
-            <BoardMap
-              config={mapConfig}
-              backdrop={visuals.backdrop}
-              backdropMode={visuals.backdropMode}
-              boardLabelMode={visuals.boardLabelMode}
+          {/* Center: map + hand strip */}
+          <div className="map-col">
+            <BoardStage className="board-panel" isMyTurn={localIsActive && publicGame.phase === "main"}>
+              <BoardMap
+                config={mapConfig}
+                backdrop={visuals.backdrop}
+                backdropMode={visuals.backdropMode}
+                boardLabelMode={visuals.boardLabelMode}
+                cardPalette={visuals.palettes.cards}
+                playerPalette={visuals.palettes.players}
+                viewerPlayerId={snapshot.privateState?.playerId ?? null}
+                game={{
+                  players: projectedGame.players.map((player) => ({
+                    id: player.id,
+                    name: player.name,
+                    color: player.color
+                  })),
+                  activePlayerIndex: projectedGame.activePlayerIndex,
+                  routeClaims: projectedGame.routeClaims,
+                  stations: projectedGame.stations
+                }}
+                selectedRouteId={selectedRouteId}
+                selectedCityId={selectedCityId}
+                highlightedCityIds={highlightedCityIds}
+                onSelectRoute={(routeId) => {
+                  setSelectedRouteId(routeId);
+                  setSelectedCityId(null);
+                  setPaymentPreview(null);
+                }}
+                onSelectCity={(cityId) => {
+                  setSelectedCityId(cityId);
+                  setSelectedRouteId(null);
+                  setPaymentPreview(null);
+                }}
+              />
+              <FloatingPlayerRoster
+                players={rosterPlayers}
+                activePlayerIndex={snapshot.game.activePlayerIndex}
+                playerPalette={visuals.palettes.players}
+                viewerPlayerId={snapshot.privateState?.playerId ?? null}
+              />
+              {/* Floating build popup */}
+              {(currentRoute || currentCity) && publicGame.phase === "main" ? (
+                <FloatingBuildPanel
+                  onClose={() => { setSelectedRouteId(null); setSelectedCityId(null); setPaymentPreview(null); }}
+                >
+                  {currentRoute ? (
+                    <SurfaceCard
+                      variant="detail"
+                      className="detail-card"
+                      data-detail-kind="route"
+                      title={`${getCityName(mapConfig, currentRoute.from)} → ${getCityName(mapConfig, currentRoute.to)}`}
+                    >
+                      <div className="detail-card__summary">
+                        <div className="detail-card__facts">
+                          <span className="detail-card__fact">{currentRoute.length} train{currentRoute.length === 1 ? "" : "s"}</span>
+                          <span className="detail-card__fact">{currentRoute.type}</span>
+                          <span className="detail-card__fact">{currentRoute.color === "gray" ? "gray route" : currentRoute.color}</span>
+                          {currentRoute.locomotiveCost ? (
+                            <span className="detail-card__fact">{currentRoute.locomotiveCost} locomotive{currentRoute.locomotiveCost === 1 ? "" : "s"}</span>
+                          ) : null}
+                        </div>
+                        <p className="detail-card__prompt">
+                          {currentRouteOwner ? `Claimed by ${currentRouteOwner.name}.` : "Choose a payment color."}
+                        </p>
+                      </div>
+                      <div className="detail-card__decision-shelf chip-row">
+                        {routeOptions.length > 0 ? (
+                          routeOptions.map((color, index) => (
+                            <ChoiceChipButton
+                              key={color}
+                              className={index === 0 && canTakeTurnAction ? "choice-chip-button--primary" : undefined}
+                              style={{ ["--choice-chip-accent" as string]: visuals.palettes.cards[color] }}
+                              disabled={!canTakeTurnAction}
+                              onMouseEnter={() => setPaymentPreview({ color, totalCost: currentRoute.length, minimumLocomotives: currentRoute.locomotiveCost ?? 0 })}
+                              onMouseLeave={() => setPaymentPreview(null)}
+                              onFocus={() => setPaymentPreview({ color, totalCost: currentRoute.length, minimumLocomotives: currentRoute.locomotiveCost ?? 0 })}
+                              onBlur={() => setPaymentPreview(null)}
+                              onClick={() => sendGameAction({ type: "claim_route", routeId: currentRoute.id, color })}
+                            >
+                              Claim {formatCardLabel(color)}
+                            </ChoiceChipButton>
+                          ))
+                        ) : (
+                          <span className="muted-copy">{currentRouteUnavailableReason}</span>
+                        )}
+                      </div>
+                    </SurfaceCard>
+                  ) : currentCity ? (
+                    <SurfaceCard variant="detail" className="detail-card" title={currentCity.name}>
+                      <div className="detail-card__summary">
+                        <div className="detail-card__facts">
+                          <span className="detail-card__fact">Station</span>
+                        </div>
+                        <p className="detail-card__prompt">Choose a payment color.</p>
+                      </div>
+                      <div className="detail-card__decision-shelf chip-row">
+                        {currentCityOccupied ? (
+                          <span className="muted-copy">A station already exists in this city.</span>
+                        ) : stationOptions.length > 0 ? (
+                          stationOptions.map((color, index) => (
+                            <ChoiceChipButton
+                              key={color}
+                              className={index === 0 && canTakeTurnAction ? "choice-chip-button--primary" : undefined}
+                              style={{ ["--choice-chip-accent" as string]: visuals.palettes.cards[color] }}
+                              disabled={!canTakeTurnAction}
+                              onMouseEnter={() => setPaymentPreview({ color, totalCost: currentStationCost })}
+                              onMouseLeave={() => setPaymentPreview(null)}
+                              onFocus={() => setPaymentPreview({ color, totalCost: currentStationCost })}
+                              onBlur={() => setPaymentPreview(null)}
+                              onClick={() => sendGameAction({ type: "build_station", cityId: currentCity.id, color })}
+                            >
+                              Build {formatCardLabel(color)}
+                            </ChoiceChipButton>
+                          ))
+                        ) : (
+                          <span className="muted-copy">
+                            {localIsActive ? "No affordable station payment colors right now." : "Wait for your turn to build a station."}
+                          </span>
+                        )}
+                      </div>
+                    </SurfaceCard>
+                  ) : null}
+                </FloatingBuildPanel>
+              ) : null}
+            </BoardStage>
+
+            <div data-tour-target="hand">
+              <PrivateHandRail hand={localPlayer.hand} cardPalette={visuals.palettes.cards} paymentPreview={paymentPreview} />
+            </div>
+          </div>
+
+          {/* Right column: chat + market */}
+          <div className="right-col" data-tour-target="market">
+            <ChatPanel
+              messages={chatMessages}
+              onSendMessage={sendChatMessage}
+            />
+            <SupplyDock
+              market={publicGame.market}
+              deckCount={publicGame.trainDeckCount}
               cardPalette={visuals.palettes.cards}
-              playerPalette={visuals.palettes.players}
-              viewerPlayerId={snapshot.privateState?.playerId ?? null}
-              game={{
-                players: projectedGame.players.map((player) => ({
-                  id: player.id,
-                  name: player.name,
-                  color: player.color
-                })),
-                activePlayerIndex: projectedGame.activePlayerIndex,
-                routeClaims: projectedGame.routeClaims,
-                stations: projectedGame.stations
-              }}
-              selectedRouteId={selectedRouteId}
-              selectedCityId={selectedCityId}
-              highlightedCityIds={highlightedCityIds}
-              onSelectRoute={(routeId) => {
-                setSelectedRouteId(routeId);
-                setSelectedCityId(null);
-                setPaymentPreview(null);
-              }}
-              onSelectCity={(cityId) => {
-                setSelectedCityId(cityId);
-                setSelectedRouteId(null);
-                setPaymentPreview(null);
-              }}
+              disabled={!canContinueDrawing}
+              isMarketCardDisabled={(card) => publicGame.turn.drawsTaken === 1 && card.color === "locomotive"}
+              onDrawFromMarket={(marketIndex) => sendGameAction({ type: "draw_card", source: "market", marketIndex })}
+              onDrawFromDeck={() => sendGameAction({ type: "draw_card", source: "deck" })}
+              className="supply-dock--board"
             />
-            <FloatingPlayerRoster
-              players={rosterPlayers}
-              activePlayerIndex={snapshot.game.activePlayerIndex}
-              playerPalette={visuals.palettes.players}
-              viewerPlayerId={snapshot.privateState?.playerId ?? null}
-            />
-          </BoardStage>
-
-          <div data-tour-target="actions" style={{ display: "contents" }}>
-          <InspectorDock
-            summary={publicGame.turn.summary}
-            className="action-panel"
-            activeBuildKey={selectedRouteId ?? selectedCityId}
-            chatMessages={chatMessages}
-            onSendChat={sendChatMessage}
-            marketContent={
-              <div data-tour-target="market">
-                <SupplyDock
-                  market={publicGame.market}
-                  deckCount={publicGame.trainDeckCount}
-                  cardPalette={visuals.palettes.cards}
-                  disabled={!canContinueDrawing}
-                  isMarketCardDisabled={(card) => publicGame.turn.drawsTaken === 1 && card.color === "locomotive"}
-                  onDrawFromMarket={(marketIndex) => sendGameAction({ type: "draw_card", source: "market", marketIndex })}
-                  onDrawFromDeck={() => sendGameAction({ type: "draw_card", source: "deck" })}
-                  onDrawTickets={() => sendGameAction({ type: "draw_tickets" })}
-                  drawTicketsDisabled={!canTakeTurnAction}
-                  className="supply-dock--board"
-                />
-              </div>
-            }
-            buildContent={
-              <>
-                {publicGame.phase === "main" && !currentRoute && !currentCity ? (
-              <div className="action-empty-prompt" data-testid="action-empty-state">
-                <span className="action-empty-prompt__title">Select a route or station.</span>
-                <span className="action-empty-prompt__copy">Build options appear here.</span>
-              </div>
-                ) : null}
-
-                {currentRoute && publicGame.phase === "main" ? (
-              <SurfaceCard
-                variant="detail"
-                className="detail-card"
-                data-detail-kind="route"
-                title={`${getCityName(mapConfig, currentRoute.from)} → ${getCityName(mapConfig, currentRoute.to)}`}
-              >
-                <div className="detail-card__summary">
-                  <div className="detail-card__facts">
-                    <span className="detail-card__fact">{currentRoute.length} train{currentRoute.length === 1 ? "" : "s"}</span>
-                    <span className="detail-card__fact">{currentRoute.type}</span>
-                    <span className="detail-card__fact">{currentRoute.color === "gray" ? "gray route" : currentRoute.color}</span>
-                    {currentRoute.locomotiveCost ? (
-                      <span className="detail-card__fact">{currentRoute.locomotiveCost} locomotive{currentRoute.locomotiveCost === 1 ? "" : "s"}</span>
-                    ) : null}
-                  </div>
-                  <p className="detail-card__prompt">
-                    {currentRouteOwner ? `Claimed by ${currentRouteOwner.name}.` : "Choose a payment color."}
-                  </p>
-                </div>
-                <div className="detail-card__decision-shelf chip-row">
-                  {routeOptions.length > 0 ? (
-                    routeOptions.map((color, index) => (
-                      <ChoiceChipButton
-                        key={color}
-                        className={index === 0 && canTakeTurnAction ? "choice-chip-button--primary" : undefined}
-                        style={{ ["--choice-chip-accent" as string]: visuals.palettes.cards[color] }}
-                        disabled={!canTakeTurnAction}
-                        onMouseEnter={() =>
-                          setPaymentPreview({ color, totalCost: currentRoute.length, minimumLocomotives: currentRoute.locomotiveCost ?? 0 })
-                        }
-                        onMouseLeave={() => setPaymentPreview(null)}
-                        onFocus={() =>
-                          setPaymentPreview({ color, totalCost: currentRoute.length, minimumLocomotives: currentRoute.locomotiveCost ?? 0 })
-                        }
-                        onBlur={() => setPaymentPreview(null)}
-                        onClick={() => sendGameAction({ type: "claim_route", routeId: currentRoute.id, color })}
-                      >
-                        Claim {formatCardLabel(color)}
-                      </ChoiceChipButton>
-                    ))
-                  ) : (
-                    <span className="muted-copy">{currentRouteUnavailableReason}</span>
-                  )}
-                </div>
-              </SurfaceCard>
-                ) : null}
-
-                {currentCity && publicGame.phase === "main" ? (
-              <SurfaceCard variant="detail" className="detail-card" title={currentCity.name}>
-                <div className="detail-card__summary">
-                  <div className="detail-card__facts">
-                    <span className="detail-card__fact">Station</span>
-                  </div>
-                  <p className="detail-card__prompt">Choose a payment color.</p>
-                </div>
-                <div className="detail-card__decision-shelf chip-row">
-                  {currentCityOccupied ? (
-                    <span className="muted-copy">A station already exists in this city.</span>
-                  ) : stationOptions.length > 0 ? (
-                    stationOptions.map((color, index) => (
-                      <ChoiceChipButton
-                        key={color}
-                        className={index === 0 && canTakeTurnAction ? "choice-chip-button--primary" : undefined}
-                        style={{ ["--choice-chip-accent" as string]: visuals.palettes.cards[color] }}
-                        disabled={!canTakeTurnAction}
-                        onMouseEnter={() => setPaymentPreview({ color, totalCost: currentStationCost })}
-                        onMouseLeave={() => setPaymentPreview(null)}
-                        onFocus={() => setPaymentPreview({ color, totalCost: currentStationCost })}
-                        onBlur={() => setPaymentPreview(null)}
-                        onClick={() => sendGameAction({ type: "build_station", cityId: currentCity.id, color })}
-                      >
-                        Build {formatCardLabel(color)}
-                      </ChoiceChipButton>
-                    ))
-                  ) : (
-                    <span className="muted-copy">
-                      {localIsActive ? "No affordable station payment colors right now." : "Wait for your turn to build a station."}
-                    </span>
-                  )}
-                </div>
-              </SurfaceCard>
-                ) : null}
-              </>
-            }
-          />
           </div>
         </main>
       </div>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -497,10 +497,10 @@ export default function App(): JSX.Element {
   function pushNotification(message: string, tone: GameplayNotification["tone"] = "neutral") {
     notificationIdRef.current += 1;
     const id = `multi-${Date.now()}-${notificationIdRef.current}`;
-    setNotifications((current) => [...current.slice(-3), { id, message, tone }]);
+    setNotifications((current) => [...current.slice(-5), { id, message, tone }]);
     window.setTimeout(() => {
       setNotifications((current) => current.filter((notification) => notification.id !== id));
-    }, 4200);
+    }, 6000);
   }
 
   useEffect(() => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -38,7 +38,6 @@ import {
   ChatPanel,
   EndgameBreakdown,
   FloatingBuildPanel,
-  FloatingPlayerRoster,
   GameOverLayer,
   NotificationPipe,
   PlayerRoster,
@@ -994,12 +993,6 @@ export default function App(): JSX.Element {
                   setSelectedRouteId(null);
                   setPaymentPreview(null);
                 }}
-              />
-              <FloatingPlayerRoster
-                players={rosterPlayers}
-                activePlayerIndex={snapshot.game.activePlayerIndex}
-                playerPalette={visuals.palettes.players}
-                viewerPlayerId={snapshot.privateState?.playerId ?? null}
               />
               {/* Floating build popup */}
               {(currentRoute || currentCity) && publicGame.phase === "main" ? (

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -501,7 +501,7 @@ export default function App(): JSX.Element {
     setNotifications((current) => [...current, { id, message, tone }]);
     window.setTimeout(() => {
       setNotifications((current) => current.filter((notification) => notification.id !== id));
-    }, 6000);
+    }, 3000);
   }
 
   useEffect(() => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -932,14 +932,16 @@ export default function App(): JSX.Element {
       </header>
 
       <div className="game-layout">
-        {/* Left column: roster + tickets + draw ticket */}
+        {/* Left column: 50/50 split — roster (top), tickets + draw button (bottom) */}
         <aside className="side-panel" data-tour-target="roster">
-          <PlayerRoster
-            players={rosterPlayers}
-            activePlayerIndex={snapshot.game.activePlayerIndex}
-            playerPalette={visuals.palettes.players}
-          />
-          <div data-tour-target="tickets">
+          <div className="side-panel__top">
+            <PlayerRoster
+              players={rosterPlayers}
+              activePlayerIndex={snapshot.game.activePlayerIndex}
+              playerPalette={visuals.palettes.players}
+            />
+          </div>
+          <div className="side-panel__bottom" data-tour-target="tickets">
             <TicketDock
               ticketProgress={ticketProgress}
               config={mapConfig}
@@ -947,15 +949,10 @@ export default function App(): JSX.Element {
               pinnedTicketId={pinnedTicket?.id ?? null}
               onFocusTicket={setFocusedTicket}
               onTogglePinnedTicket={(ticket) => setPinnedTicket((current) => current?.id === ticket.id ? null : ticket)}
+              onDrawTickets={() => sendGameAction({ type: "draw_tickets" })}
+              drawTicketsDisabled={!canTakeTurnAction}
             />
           </div>
-          <Button
-            className="side-panel__draw-ticket"
-            disabled={!canTakeTurnAction}
-            onClick={() => sendGameAction({ type: "draw_tickets" })}
-          >
-            Draw tickets
-          </Button>
         </aside>
 
         <main className="board-column">

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -501,7 +501,7 @@ export default function App(): JSX.Element {
     setNotifications((current) => [...current, { id, message, tone }]);
     window.setTimeout(() => {
       setNotifications((current) => current.filter((notification) => notification.id !== id));
-    }, 3000);
+    }, 2000);
   }
 
   useEffect(() => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -218,6 +218,7 @@ export default function App(): JSX.Element {
   const notificationIdRef = useRef(0);
   const lastAnnouncedLogRef = useRef<string | null>(null);
   const lastAnnouncedLogLengthRef = useRef(0);
+  const pendingDrawsRef = useRef<{ player: string; cards: string[] } | null>(null);
   const timerWarningRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -523,13 +524,50 @@ export default function App(): JSX.Element {
       return;
     }
 
-    // Push every new log entry — but only draw/claim actions, skip turn changes
+    // Push notable log entries (draw/claim/station). Draws within one turn are
+    // batched into a single notification flushed when the turn ends or another
+    // action type appears.
     const newEntries = log.slice(lastAnnouncedLogLengthRef.current);
+    const tone = snapshot.game.phase === "gameOver" ? "success" : "neutral";
+
+    function flushDraws() {
+      const pending = pendingDrawsRef.current;
+      if (pending && pending.cards.length > 0) {
+        const cardList = pending.cards.join(", ");
+        pushNotification(`${pending.player} drew ${cardList}.`, tone);
+      }
+      pendingDrawsRef.current = null;
+    }
+
     for (const entry of newEntries) {
-      if (entry.includes("drew") || entry.includes("claimed") || entry.includes("built a station")) {
-        pushNotification(entry, snapshot.game.phase === "gameOver" ? "success" : "neutral");
+      // "X drew a Y card."
+      const drawMatch = entry.match(/^(.+) drew a (.+) card\.$/);
+      if (drawMatch) {
+        const [, player, card] = drawMatch;
+        if (pendingDrawsRef.current && pendingDrawsRef.current.player !== player) {
+          flushDraws();
+        }
+        if (!pendingDrawsRef.current) {
+          pendingDrawsRef.current = { player, cards: [] };
+        }
+        pendingDrawsRef.current.cards.push(card);
+        continue;
+      }
+      // Other notable actions — flush pending draws first, then announce
+      if (entry.includes("claimed") || entry.includes("built a station")) {
+        flushDraws();
+        pushNotification(entry, tone);
+        continue;
+      }
+      // Turn started — flush pending draws so they're announced at end of turn
+      if (entry.includes("turn started")) {
+        flushDraws();
       }
     }
+
+    // Do NOT flush here — let pending draws batch until the next "turn started"
+    // log arrives (which marks end of this player's draw phase).
+
     lastAnnouncedLogLengthRef.current = log.length;
     lastAnnouncedLogRef.current = log[log.length - 1];
   }, [snapshot?.game?.log.length, snapshot?.game?.phase]);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -523,10 +523,12 @@ export default function App(): JSX.Element {
       return;
     }
 
-    // Push every new log entry since last fire
+    // Push every new log entry — but only draw/claim actions, skip turn changes
     const newEntries = log.slice(lastAnnouncedLogLengthRef.current);
     for (const entry of newEntries) {
-      pushNotification(entry, snapshot.game.phase === "gameOver" ? "success" : "neutral");
+      if (entry.includes("drew") || entry.includes("claimed") || entry.includes("built a station")) {
+        pushNotification(entry, snapshot.game.phase === "gameOver" ? "success" : "neutral");
+      }
     }
     lastAnnouncedLogLengthRef.current = log.length;
     lastAnnouncedLogRef.current = log[log.length - 1];

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -504,24 +504,32 @@ export default function App(): JSX.Element {
   }
 
   useEffect(() => {
-    const latestLog = snapshot?.game?.log.at(-1);
-    if (!snapshot?.game || !latestLog) {
+    const log = snapshot?.game?.log;
+    if (!snapshot?.game || !log || log.length === 0) {
       return;
     }
 
-    if (!lastAnnouncedLogRef.current) {
-      lastAnnouncedLogRef.current = latestLog;
-      lastAnnouncedLogLengthRef.current = snapshot.game.log.length;
+    // First time we see this game — initialise without firing notifications
+    if (lastAnnouncedLogLengthRef.current === 0) {
+      lastAnnouncedLogLengthRef.current = log.length;
+      lastAnnouncedLogRef.current = log[log.length - 1];
       return;
     }
 
-    if (snapshot.game.log.length <= lastAnnouncedLogLengthRef.current) {
+    // If log somehow shrank (game reset / reconnect), resync without notifying
+    if (log.length < lastAnnouncedLogLengthRef.current) {
+      lastAnnouncedLogLengthRef.current = log.length;
+      lastAnnouncedLogRef.current = log[log.length - 1] ?? null;
       return;
     }
 
-    lastAnnouncedLogRef.current = latestLog;
-    lastAnnouncedLogLengthRef.current = snapshot.game.log.length;
-    pushNotification(latestLog, snapshot.game.phase === "gameOver" ? "success" : "neutral");
+    // Push every new log entry since last fire
+    const newEntries = log.slice(lastAnnouncedLogLengthRef.current);
+    for (const entry of newEntries) {
+      pushNotification(entry, snapshot.game.phase === "gameOver" ? "success" : "neutral");
+    }
+    lastAnnouncedLogLengthRef.current = log.length;
+    lastAnnouncedLogRef.current = log[log.length - 1];
   }, [snapshot?.game?.log.length, snapshot?.game?.phase]);
 
   const liveTimerSecondsRemaining =

--- a/apps/web/src/components/screens/LocalPlayScreen.tsx
+++ b/apps/web/src/components/screens/LocalPlayScreen.tsx
@@ -71,6 +71,7 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
   const [visibility, setVisibility] = useState<VisibilityMode>("visible");
   const [selectedRouteId, setSelectedRouteId] = useState<string | null>(null);
   const [selectedCityId, setSelectedCityId] = useState<string | null>(null);
+  const [buildAnchor, setBuildAnchor] = useState<{ x: number; y: number } | null>(null);
   const [selectedTicketIds, setSelectedTicketIds] = useState<string[]>([]);
   const [focusedTicket, setFocusedTicket] = useState<TicketDef | null>(null);
   const [pinnedTicket, setPinnedTicket] = useState<TicketDef | null>(null);
@@ -447,14 +448,15 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
                 selectedRouteId={selectedRouteId}
                 selectedCityId={selectedCityId}
                 highlightedCityIds={highlightedCityIds}
-                onSelectRoute={(routeId) => { setSelectedRouteId(routeId); setSelectedCityId(null); setPaymentPreview(null); }}
-                onSelectCity={(cityId) => { setSelectedCityId(cityId); setSelectedRouteId(null); setPaymentPreview(null); }}
+                onSelectRoute={(routeId, position) => { setSelectedRouteId(routeId); setSelectedCityId(null); setPaymentPreview(null); setBuildAnchor(position ?? null); }}
+                onSelectCity={(cityId, position) => { setSelectedCityId(cityId); setSelectedRouteId(null); setPaymentPreview(null); setBuildAnchor(position ?? null); }}
               />
 
               {/* Floating build popup — appears on map when route/city selected */}
               {(currentRoute || currentCity) && game.phase === "main" && visibility === "visible" ? (
                 <FloatingBuildPanel
-                  onClose={() => { setSelectedRouteId(null); setSelectedCityId(null); setPaymentPreview(null); }}
+                  anchor={buildAnchor}
+                  onClose={() => { setSelectedRouteId(null); setSelectedCityId(null); setPaymentPreview(null); setBuildAnchor(null); }}
                 >
                   {currentRoute ? (
                     <RouteBuildPanel

--- a/apps/web/src/components/screens/LocalPlayScreen.tsx
+++ b/apps/web/src/components/screens/LocalPlayScreen.tsx
@@ -25,7 +25,6 @@ import {
   BoardStage,
   ChatPanel,
   FloatingBuildPanel,
-  FloatingPlayerRoster,
   PlayerRoster,
   GameOverLayer,
   NotificationPipe,
@@ -431,13 +430,6 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
                 highlightedCityIds={highlightedCityIds}
                 onSelectRoute={(routeId) => { setSelectedRouteId(routeId); setSelectedCityId(null); setPaymentPreview(null); }}
                 onSelectCity={(cityId) => { setSelectedCityId(cityId); setSelectedRouteId(null); setPaymentPreview(null); }}
-              />
-
-              <FloatingPlayerRoster
-                players={rosterPlayers}
-                activePlayerIndex={game.activePlayerIndex}
-                playerPalette={playerColorPalette}
-                viewerPlayerId={game.players[game.activePlayerIndex]?.id ?? null}
               />
 
               {/* Floating build popup — appears on map when route/city selected */}

--- a/apps/web/src/components/screens/LocalPlayScreen.tsx
+++ b/apps/web/src/components/screens/LocalPlayScreen.tsx
@@ -118,10 +118,10 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
   function pushNotification(message: string, tone: GameplayNotification["tone"] = "neutral") {
     notificationIdRef.current += 1;
     const id = `local-${Date.now()}-${notificationIdRef.current}`;
-    setNotifications((current) => [...current.slice(-3), { id, message, tone }]);
+    setNotifications((current) => [...current.slice(-5), { id, message, tone }]);
     window.setTimeout(() => {
       setNotifications((current) => current.filter((n) => n.id !== id));
-    }, 4200);
+    }, 6000);
   }
 
   function announceGameChange(previous: GameState, nextGame: GameState) {

--- a/apps/web/src/components/screens/LocalPlayScreen.tsx
+++ b/apps/web/src/components/screens/LocalPlayScreen.tsx
@@ -23,9 +23,9 @@ import {
 import {
   BoardMap,
   BoardStage,
+  ChatPanel,
   FloatingPlayerRoster,
   GameOverLayer,
-  InspectorDock,
   NotificationPipe,
   PrivateHandRail,
   SupplyDock,
@@ -368,14 +368,15 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
       </header>
 
       <div className={`game-layout ${visibility !== "visible" ? "game-layout--obscured" : ""} ${tutorialTarget ? "game-layout--tutorial" : ""}`}>
-        <aside className="side-panel">
+        {/* Left column: roster + tickets + draw ticket */}
+        <aside className="side-panel" data-tour-target="roster">
           {visibility === "visible" ? (
-            <div className="side-panel__private-stack">
-              <PrivateHandRail
-                hand={activePlayer.hand}
-                cardPalette={cardColorPalette}
-                paymentPreview={paymentPreview}
-                className={tutorialTarget === "hand" ? "panel--tutorial-focus" : ""}
+            <>
+              <FloatingPlayerRoster
+                players={rosterPlayers}
+                activePlayerIndex={game.activePlayerIndex}
+                playerPalette={playerColorPalette}
+                viewerPlayerId={game.players[game.activePlayerIndex]?.id ?? null}
               />
               <TicketDock
                 ticketProgress={ticketProgress}
@@ -384,9 +385,16 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
                 pinnedTicketId={pinnedTicket?.id ?? null}
                 onFocusTicket={setFocusedTicket}
                 onTogglePinnedTicket={(ticket) => setPinnedTicket((current) => current?.id === ticket.id ? null : ticket)}
-                className={tutorialTarget === "hand" ? "panel--tutorial-focus" : ""}
+                className={tutorialTarget === "tickets" ? "panel--tutorial-focus" : ""}
               />
-            </div>
+              <Button
+                className="side-panel__draw-ticket"
+                disabled={!canTakeTurnAction}
+                onClick={() => applyAction({ type: "draw_tickets" })}
+              >
+                Draw tickets
+              </Button>
+            </>
           ) : (
             <Panel variant="danger" className="hidden-panel">
               <SectionHeader eyebrow="Privacy shield" title="Private info hidden" variant="standard" />
@@ -395,111 +403,59 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
           )}
         </aside>
 
+        {/* Center + right: board-column grid */}
         <main className="board-column">
-          <BoardStage
-            className={`board-panel ${tutorialTarget === "board" ? "panel--tutorial-focus" : ""}`}
-            isMyTurn={visibility === "visible" && game.phase === "main"}
-          >
-            <BoardMap
-              config={localMap}
-              backdrop={localVisuals.backdrop}
-              backdropMode={localVisuals.backdropMode}
-              boardLabelMode={localVisuals.boardLabelMode}
-              cardPalette={cardColorPalette}
-              playerPalette={playerColorPalette}
-              viewerPlayerId={game.players[game.activePlayerIndex]?.id}
-              game={{
-                players: game.players.map((p) => ({ id: p.id, name: p.name, color: p.color })),
-                activePlayerIndex: game.activePlayerIndex,
-                routeClaims: game.routeClaims,
-                stations: game.stations
-              }}
-              selectedRouteId={selectedRouteId}
-              selectedCityId={selectedCityId}
-              highlightedCityIds={highlightedCityIds}
-              onSelectRoute={(routeId) => { setSelectedRouteId(routeId); setSelectedCityId(null); setPaymentPreview(null); }}
-              onSelectCity={(cityId) => { setSelectedCityId(cityId); setSelectedRouteId(null); setPaymentPreview(null); }}
-            />
-            <FloatingPlayerRoster
-              players={rosterPlayers}
-              activePlayerIndex={game.activePlayerIndex}
-              playerPalette={playerColorPalette}
-              viewerPlayerId={game.players[game.activePlayerIndex]?.id ?? null}
-            />
-          </BoardStage>
-
-          <InspectorDock
-            summary={game.turn.summary}
-            className={`action-panel ${tutorialTarget === "action" ? "panel--tutorial-focus" : ""}`}
-            activeBuildKey={selectedRouteId ?? selectedCityId}
-            currentPlayerName={game.players[game.activePlayerIndex]?.name}
-            deckCount={game.trainDeck.length}
-            ticketDeckCount={game.regularTickets.length + game.longTickets.length}
-            marketContent={
-              <SupplyDock
-                market={game.market}
-                deckCount={game.trainDeck.length}
+          {/* Center: map + hand strip */}
+          <div className="map-col">
+            <BoardStage
+              className={`board-panel ${tutorialTarget === "board" ? "panel--tutorial-focus" : ""}`}
+              isMyTurn={visibility === "visible" && game.phase === "main"}
+            >
+              <BoardMap
+                config={localMap}
+                backdrop={localVisuals.backdrop}
+                backdropMode={localVisuals.backdropMode}
+                boardLabelMode={localVisuals.boardLabelMode}
                 cardPalette={cardColorPalette}
-                disabled={marketDisabled}
-                onDrawFromMarket={(marketIndex) => applyAction({ type: "draw_card", source: "market", marketIndex })}
-                onDrawFromDeck={() => applyAction({ type: "draw_card", source: "deck" })}
-                onDrawTickets={() => applyAction({ type: "draw_tickets" })}
-                drawTicketsDisabled={!canTakeTurnAction}
-                className={`supply-dock--board ${tutorialTarget === "market" ? "panel--tutorial-focus" : ""}`}
+                playerPalette={playerColorPalette}
+                viewerPlayerId={game.players[game.activePlayerIndex]?.id}
+                game={{
+                  players: game.players.map((p) => ({ id: p.id, name: p.name, color: p.color })),
+                  activePlayerIndex: game.activePlayerIndex,
+                  routeClaims: game.routeClaims,
+                  stations: game.stations
+                }}
+                selectedRouteId={selectedRouteId}
+                selectedCityId={selectedCityId}
+                highlightedCityIds={highlightedCityIds}
+                onSelectRoute={(routeId) => { setSelectedRouteId(routeId); setSelectedCityId(null); setPaymentPreview(null); }}
+                onSelectCity={(cityId) => { setSelectedCityId(cityId); setSelectedRouteId(null); setPaymentPreview(null); }}
               />
-            }
-            buildContent={
-              <>
-                {game.phase === "main" && visibility === "visible" && !currentRoute && !currentCity ? (
-                  <div className="action-empty-prompt" data-testid="action-empty-state">
-                    <span className="action-empty-prompt__title">Select a route or station.</span>
-                    <span className="action-empty-prompt__copy">Build options appear here.</span>
-                  </div>
-                ) : null}
+            </BoardStage>
 
-                {currentRoute && game.phase === "main" && visibility === "visible" ? (
-                  <RouteBuildPanel
-                    route={currentRoute}
-                    config={localMap}
-                    options={routeOptions}
-                    unavailableReason={currentRouteUnavailableReason}
-                    cardPalette={cardColorPalette}
-                    disabled={!canTakeTurnAction}
-                    claimedByName={currentRouteOwner?.name ?? null}
-                    onClaim={(color) => applyAction({ type: "claim_route", routeId: currentRoute.id, color })}
-                    onPaymentPreviewEnter={(preview) => setPaymentPreview(preview)}
-                    onPaymentPreviewLeave={() => setPaymentPreview(null)}
-                  />
-                ) : null}
+            {visibility === "visible" ? (
+              <PrivateHandRail
+                hand={activePlayer.hand}
+                cardPalette={cardColorPalette}
+                paymentPreview={paymentPreview}
+                className={tutorialTarget === "hand" ? "panel--tutorial-focus" : ""}
+              />
+            ) : null}
+          </div>
 
-                {currentCity && game.phase === "main" && visibility === "visible" ? (
-                  <StationBuildPanel
-                    city={currentCity}
-                    config={localMap}
-                    options={stationOptions}
-                    cityOccupied={currentCityOccupied}
-                    stationCost={currentStationCost}
-                    cardPalette={cardColorPalette}
-                    disabled={!canTakeTurnAction}
-                    turnStage={game.turn.stage}
-                    onBuild={(color) => applyAction({ type: "build_station", cityId: currentCity.id, color })}
-                    onPaymentPreviewEnter={(preview) => setPaymentPreview(preview)}
-                    onPaymentPreviewLeave={() => setPaymentPreview(null)}
-                  />
-                ) : null}
-
-                {game.turn.latestTunnelReveal.length > 0 && visibility === "visible" ? (
-                  <SurfaceCard variant="detail" className="detail-card detail-card--tunnel" eyebrow="Tunnel check" title="Tunnel reveal">
-                    <p>{game.turn.latestTunnelReveal.join(", ")}</p>
-                  </SurfaceCard>
-                ) : null}
-
-                {error && visibility === "visible" ? (
-                  <StatusBanner tone="warning" eyebrow="Action error" headline={error} />
-                ) : null}
-              </>
-            }
-          />
+          {/* Right column: chat + market */}
+          <div className="right-col" data-tour-target="market">
+            <ChatPanel className={tutorialTarget === "action" ? "panel--tutorial-focus" : ""} />
+            <SupplyDock
+              market={game.market}
+              deckCount={game.trainDeck.length}
+              cardPalette={cardColorPalette}
+              disabled={marketDisabled}
+              onDrawFromMarket={(marketIndex) => applyAction({ type: "draw_card", source: "market", marketIndex })}
+              onDrawFromDeck={() => applyAction({ type: "draw_card", source: "deck" })}
+              className={`supply-dock--board ${tutorialTarget === "market" ? "panel--tutorial-focus" : ""}`}
+            />
+          </div>
         </main>
       </div>
 

--- a/apps/web/src/components/screens/LocalPlayScreen.tsx
+++ b/apps/web/src/components/screens/LocalPlayScreen.tsx
@@ -387,31 +387,35 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
       </header>
 
       <div className={`game-layout ${visibility !== "visible" ? "game-layout--obscured" : ""} ${tutorialTarget ? "game-layout--tutorial" : ""}`}>
-        {/* Left column: roster + tickets + draw ticket */}
+        {/* Left column: 50/50 split — roster (top), tickets + draw button (bottom) */}
         <aside className="side-panel" data-tour-target="roster">
           {visibility === "visible" ? (
             <>
-              <PlayerRoster
-                players={rosterPlayers}
-                activePlayerIndex={game.activePlayerIndex}
-                playerPalette={playerColorPalette}
-              />
-              <TicketDock
-                ticketProgress={ticketProgress}
-                config={localMap}
-                focusedTicketId={focusedTicket?.id ?? null}
-                pinnedTicketId={pinnedTicket?.id ?? null}
-                onFocusTicket={setFocusedTicket}
-                onTogglePinnedTicket={(ticket) => setPinnedTicket((current) => current?.id === ticket.id ? null : ticket)}
-                className={tutorialTarget === "tickets" ? "panel--tutorial-focus" : ""}
-              />
-              <Button
-                className="side-panel__draw-ticket"
-                disabled={!canTakeTurnAction}
-                onClick={() => applyAction({ type: "draw_tickets" })}
-              >
-                Draw tickets
-              </Button>
+              <div className="side-panel__top">
+                <PlayerRoster
+                  players={rosterPlayers}
+                  activePlayerIndex={game.activePlayerIndex}
+                  playerPalette={playerColorPalette}
+                />
+              </div>
+              <div className="side-panel__bottom">
+                <TicketDock
+                  ticketProgress={ticketProgress}
+                  config={localMap}
+                  focusedTicketId={focusedTicket?.id ?? null}
+                  pinnedTicketId={pinnedTicket?.id ?? null}
+                  onFocusTicket={setFocusedTicket}
+                  onTogglePinnedTicket={(ticket) => setPinnedTicket((current) => current?.id === ticket.id ? null : ticket)}
+                  className={tutorialTarget === "tickets" ? "panel--tutorial-focus" : ""}
+                />
+                <Button
+                  className="side-panel__draw-ticket"
+                  disabled={!canTakeTurnAction}
+                  onClick={() => applyAction({ type: "draw_tickets" })}
+                >
+                  Draw tickets
+                </Button>
+              </div>
             </>
           ) : (
             <Panel variant="danger" className="hidden-panel">

--- a/apps/web/src/components/screens/LocalPlayScreen.tsx
+++ b/apps/web/src/components/screens/LocalPlayScreen.tsx
@@ -122,7 +122,7 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
     setNotifications((current) => [...current, { id, message, tone }]);
     window.setTimeout(() => {
       setNotifications((current) => current.filter((n) => n.id !== id));
-    }, 3000);
+    }, 2000);
   }
 
   function flushPendingDraws() {

--- a/apps/web/src/components/screens/LocalPlayScreen.tsx
+++ b/apps/web/src/components/screens/LocalPlayScreen.tsx
@@ -119,7 +119,7 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
   function pushNotification(message: string, tone: GameplayNotification["tone"] = "neutral") {
     notificationIdRef.current += 1;
     const id = `local-${Date.now()}-${notificationIdRef.current}`;
-    setNotifications((current) => [...current.slice(-5), { id, message, tone }]);
+    setNotifications((current) => [...current, { id, message, tone }]);
     window.setTimeout(() => {
       setNotifications((current) => current.filter((n) => n.id !== id));
     }, 6000);

--- a/apps/web/src/components/screens/LocalPlayScreen.tsx
+++ b/apps/web/src/components/screens/LocalPlayScreen.tsx
@@ -26,6 +26,7 @@ import {
   ChatPanel,
   FloatingBuildPanel,
   FloatingPlayerRoster,
+  PlayerRoster,
   GameOverLayer,
   NotificationPipe,
   PrivateHandRail,
@@ -373,11 +374,10 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
         <aside className="side-panel" data-tour-target="roster">
           {visibility === "visible" ? (
             <>
-              <FloatingPlayerRoster
+              <PlayerRoster
                 players={rosterPlayers}
                 activePlayerIndex={game.activePlayerIndex}
                 playerPalette={playerColorPalette}
-                viewerPlayerId={game.players[game.activePlayerIndex]?.id ?? null}
               />
               <TicketDock
                 ticketProgress={ticketProgress}
@@ -431,6 +431,13 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
                 highlightedCityIds={highlightedCityIds}
                 onSelectRoute={(routeId) => { setSelectedRouteId(routeId); setSelectedCityId(null); setPaymentPreview(null); }}
                 onSelectCity={(cityId) => { setSelectedCityId(cityId); setSelectedRouteId(null); setPaymentPreview(null); }}
+              />
+
+              <FloatingPlayerRoster
+                players={rosterPlayers}
+                activePlayerIndex={game.activePlayerIndex}
+                playerPalette={playerColorPalette}
+                viewerPlayerId={game.players[game.activePlayerIndex]?.id ?? null}
               />
 
               {/* Floating build popup — appears on map when route/city selected */}

--- a/apps/web/src/components/screens/LocalPlayScreen.tsx
+++ b/apps/web/src/components/screens/LocalPlayScreen.tsx
@@ -85,6 +85,8 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
   const [notifications, setNotifications] = useState<GameplayNotification[]>([]);
   const notificationIdRef = useRef(0);
+  const [localChat, setLocalChat] = useState<Array<{ id: string; playerName: string; message: string }>>([]);
+  const chatIdRef = useRef(0);
   const [turnStartedAt, setTurnStartedAt] = useState<number>(() => Date.now());
   const [nowMs, setNowMs] = useState<number>(() => Date.now());
   const localMap = useMemo(() => getHudsonHustleMapByConfigId(localConfigId), [localConfigId]);
@@ -506,7 +508,17 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
 
           {/* Right column: chat + market — overlaid by ticket picker when active */}
           <div className="right-col" data-tour-target="market">
-            <ChatPanel className={tutorialTarget === "action" ? "panel--tutorial-focus" : ""} />
+            <ChatPanel
+              messages={localChat}
+              onSendMessage={(message) => {
+                chatIdRef.current += 1;
+                setLocalChat((current) => [
+                  ...current,
+                  { id: `local-chat-${chatIdRef.current}`, playerName: activePlayer.name, message }
+                ]);
+              }}
+              className={tutorialTarget === "action" ? "panel--tutorial-focus" : ""}
+            />
             <SupplyDock
               market={game.market}
               deckCount={game.trainDeck.length}

--- a/apps/web/src/components/screens/LocalPlayScreen.tsx
+++ b/apps/web/src/components/screens/LocalPlayScreen.tsx
@@ -24,6 +24,7 @@ import {
   BoardMap,
   BoardStage,
   ChatPanel,
+  FloatingBuildPanel,
   FloatingPlayerRoster,
   GameOverLayer,
   NotificationPipe,
@@ -431,6 +432,50 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
                 onSelectRoute={(routeId) => { setSelectedRouteId(routeId); setSelectedCityId(null); setPaymentPreview(null); }}
                 onSelectCity={(cityId) => { setSelectedCityId(cityId); setSelectedRouteId(null); setPaymentPreview(null); }}
               />
+
+              {/* Floating build popup — appears on map when route/city selected */}
+              {(currentRoute || currentCity) && game.phase === "main" && visibility === "visible" ? (
+                <FloatingBuildPanel
+                  onClose={() => { setSelectedRouteId(null); setSelectedCityId(null); setPaymentPreview(null); }}
+                >
+                  {currentRoute ? (
+                    <RouteBuildPanel
+                      route={currentRoute}
+                      config={localMap}
+                      options={routeOptions}
+                      unavailableReason={currentRouteUnavailableReason}
+                      cardPalette={cardColorPalette}
+                      disabled={!canTakeTurnAction}
+                      claimedByName={currentRouteOwner?.name ?? null}
+                      onClaim={(color) => applyAction({ type: "claim_route", routeId: currentRoute.id, color })}
+                      onPaymentPreviewEnter={(preview) => setPaymentPreview(preview)}
+                      onPaymentPreviewLeave={() => setPaymentPreview(null)}
+                    />
+                  ) : currentCity ? (
+                    <StationBuildPanel
+                      city={currentCity}
+                      config={localMap}
+                      options={stationOptions}
+                      cityOccupied={currentCityOccupied}
+                      stationCost={currentStationCost}
+                      cardPalette={cardColorPalette}
+                      disabled={!canTakeTurnAction}
+                      turnStage={game.turn.stage}
+                      onBuild={(color) => applyAction({ type: "build_station", cityId: currentCity.id, color })}
+                      onPaymentPreviewEnter={(preview) => setPaymentPreview(preview)}
+                      onPaymentPreviewLeave={() => setPaymentPreview(null)}
+                    />
+                  ) : null}
+                  {game.turn.latestTunnelReveal.length > 0 ? (
+                    <SurfaceCard variant="detail" className="detail-card detail-card--tunnel" eyebrow="Tunnel check" title="Tunnel reveal">
+                      <p>{game.turn.latestTunnelReveal.join(", ")}</p>
+                    </SurfaceCard>
+                  ) : null}
+                  {error ? (
+                    <StatusBanner tone="warning" eyebrow="Action error" headline={error} />
+                  ) : null}
+                </FloatingBuildPanel>
+              ) : null}
             </BoardStage>
 
             {visibility === "visible" ? (

--- a/apps/web/src/components/screens/LocalPlayScreen.tsx
+++ b/apps/web/src/components/screens/LocalPlayScreen.tsx
@@ -361,9 +361,9 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
         <div className="topbar-private-spacer" aria-hidden="true" />
         <TurnIndicator playerName={game.players[game.activePlayerIndex]?.name ?? ""} />
         <div className="topbar-actions">
-          <Button onClick={() => setGuideOpen(true)}>Guide</Button>
-          <ScoreGuide className="score-guide--subtle" label="Score" />
-          <Button onClick={() => setShowLeaveConfirm(true)}>Leave room</Button>
+          <Button className="topbar-icon-btn" aria-label="Guide" onClick={() => setGuideOpen(true)} data-label="Guide">?</Button>
+          <ScoreGuide className="score-guide--subtle topbar-icon-btn" label="★" />
+          <Button className="topbar-icon-btn topbar-icon-btn--leave" aria-label="Leave room" onClick={() => setShowLeaveConfirm(true)} data-label="Leave">✕</Button>
         </div>
       </header>
 

--- a/apps/web/src/components/screens/LocalPlayScreen.tsx
+++ b/apps/web/src/components/screens/LocalPlayScreen.tsx
@@ -135,7 +135,12 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
       pushNotification(`${triggerPlayer?.name ?? "A player"} triggered the final round.`, "warning");
       return;
     }
-    if (nextLog && nextGame.log.length > previous.log.length && nextLog !== "Game setup complete.") {
+    if (
+      nextLog
+      && nextGame.log.length > previous.log.length
+      && nextLog !== "Game setup complete."
+      && (nextLog.includes("drew") || nextLog.includes("claimed") || nextLog.includes("built a station"))
+    ) {
       pushNotification(nextLog);
     }
   }

--- a/apps/web/src/components/screens/LocalPlayScreen.tsx
+++ b/apps/web/src/components/screens/LocalPlayScreen.tsx
@@ -406,15 +406,10 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
                   pinnedTicketId={pinnedTicket?.id ?? null}
                   onFocusTicket={setFocusedTicket}
                   onTogglePinnedTicket={(ticket) => setPinnedTicket((current) => current?.id === ticket.id ? null : ticket)}
+                  onDrawTickets={() => applyAction({ type: "draw_tickets" })}
+                  drawTicketsDisabled={!canTakeTurnAction}
                   className={tutorialTarget === "tickets" ? "panel--tutorial-focus" : ""}
                 />
-                <Button
-                  className="side-panel__draw-ticket"
-                  disabled={!canTakeTurnAction}
-                  onClick={() => applyAction({ type: "draw_tickets" })}
-                >
-                  Draw tickets
-                </Button>
               </div>
             </>
           ) : (

--- a/apps/web/src/components/screens/LocalPlayScreen.tsx
+++ b/apps/web/src/components/screens/LocalPlayScreen.tsx
@@ -122,7 +122,7 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
     setNotifications((current) => [...current, { id, message, tone }]);
     window.setTimeout(() => {
       setNotifications((current) => current.filter((n) => n.id !== id));
-    }, 6000);
+    }, 3000);
   }
 
   function flushPendingDraws() {

--- a/apps/web/src/components/screens/LocalPlayScreen.tsx
+++ b/apps/web/src/components/screens/LocalPlayScreen.tsx
@@ -364,7 +364,7 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
         <TurnIndicator playerName={game.players[game.activePlayerIndex]?.name ?? ""} />
         <div className="topbar-actions">
           <Button className="topbar-icon-btn" aria-label="Guide" onClick={() => setGuideOpen(true)} data-label="Guide">?</Button>
-          <ScoreGuide className="score-guide--subtle topbar-icon-btn" label="★" />
+          <ScoreGuide className="score-guide--subtle topbar-icon-btn" label="★" tooltipLabel="Score" />
           <Button className="topbar-icon-btn topbar-icon-btn--leave" aria-label="Leave room" onClick={() => setShowLeaveConfirm(true)} data-label="Leave">✕</Button>
         </div>
       </header>

--- a/apps/web/src/components/screens/LocalPlayScreen.tsx
+++ b/apps/web/src/components/screens/LocalPlayScreen.tsx
@@ -86,6 +86,7 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
   const [notifications, setNotifications] = useState<GameplayNotification[]>([]);
   const notificationIdRef = useRef(0);
+  const pendingDrawsRef = useRef<{ player: string; cards: string[] } | null>(null);
   const [localChat, setLocalChat] = useState<Array<{ id: string; playerName: string; message: string }>>([]);
   const chatIdRef = useRef(0);
   const [turnStartedAt, setTurnStartedAt] = useState<number>(() => Date.now());
@@ -124,24 +125,53 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
     }, 6000);
   }
 
+  function flushPendingDraws() {
+    const pending = pendingDrawsRef.current;
+    if (pending && pending.cards.length > 0) {
+      const cardList = pending.cards.join(", ");
+      pushNotification(`${pending.player} drew ${cardList}.`);
+    }
+    pendingDrawsRef.current = null;
+  }
+
   function announceGameChange(previous: GameState, nextGame: GameState) {
-    const nextLog = nextGame.log.at(-1);
     if (nextGame.phase === "gameOver" && previous.phase !== "gameOver") {
+      flushPendingDraws();
       pushNotification("Final scores are in.", "success");
       return;
     }
     if (nextGame.finalRoundTriggeredBy && previous.finalRoundTriggeredBy !== nextGame.finalRoundTriggeredBy) {
+      flushPendingDraws();
       const triggerPlayer = nextGame.players.find((p) => p.id === nextGame.finalRoundTriggeredBy);
       pushNotification(`${triggerPlayer?.name ?? "A player"} triggered the final round.`, "warning");
       return;
     }
-    if (
-      nextLog
-      && nextGame.log.length > previous.log.length
-      && nextLog !== "Game setup complete."
-      && (nextLog.includes("drew") || nextLog.includes("claimed") || nextLog.includes("built a station"))
-    ) {
-      pushNotification(nextLog);
+
+    // Walk every new log entry; batch consecutive draws per player into one notification
+    const newEntries = nextGame.log.slice(previous.log.length);
+    for (const entry of newEntries) {
+      if (entry === "Game setup complete.") continue;
+
+      const drawMatch = entry.match(/^(.+) drew a (.+) card\.$/);
+      if (drawMatch) {
+        const [, player, card] = drawMatch;
+        if (pendingDrawsRef.current && pendingDrawsRef.current.player !== player) {
+          flushPendingDraws();
+        }
+        if (!pendingDrawsRef.current) {
+          pendingDrawsRef.current = { player, cards: [] };
+        }
+        pendingDrawsRef.current.cards.push(card);
+        continue;
+      }
+      if (entry.includes("claimed") || entry.includes("built a station")) {
+        flushPendingDraws();
+        pushNotification(entry);
+        continue;
+      }
+      if (entry.includes("turn started")) {
+        flushPendingDraws();
+      }
     }
   }
 

--- a/apps/web/src/components/screens/LocalPlayScreen.tsx
+++ b/apps/web/src/components/screens/LocalPlayScreen.tsx
@@ -495,7 +495,7 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
             ) : null}
           </div>
 
-          {/* Right column: chat + market */}
+          {/* Right column: chat + market — overlaid by ticket picker when active */}
           <div className="right-col" data-tour-target="market">
             <ChatPanel className={tutorialTarget === "action" ? "panel--tutorial-focus" : ""} />
             <SupplyDock
@@ -507,6 +507,34 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
               onDrawFromDeck={() => applyAction({ type: "draw_card", source: "deck" })}
               className={`supply-dock--board ${tutorialTarget === "market" ? "panel--tutorial-focus" : ""}`}
             />
+            {pendingTickets.length > 0 && visibility === "visible" && !isCurrentPlayerLocalBot ? (
+              <TicketChoiceSheet
+                title={game.phase === "initialTickets" ? `${activePlayer.name}, choose starting tickets` : `${activePlayer.name}, keep new tickets`}
+                subtitle={
+                  game.phase === "initialTickets"
+                    ? "Keep at least two. Anything you return is gone for this game."
+                    : "Keep at least one. This counts as your full turn."
+                }
+                tickets={pendingTickets}
+                config={localMap}
+                minimumKeep={game.phase === "initialTickets" ? 2 : 1}
+                selectedIds={selectedTicketIds}
+                focusedTicketId={focusedTicket?.id ?? null}
+                onFocusTicket={setFocusedTicket}
+                onToggle={(ticketId) =>
+                  setSelectedTicketIds((current) =>
+                    current.includes(ticketId) ? current.filter((id) => id !== ticketId) : [...current, ticketId]
+                  )
+                }
+                onConfirm={() =>
+                  applyAction(
+                    game.phase === "initialTickets"
+                      ? { type: "select_initial_tickets", keptTicketIds: selectedTicketIds }
+                      : { type: "keep_drawn_tickets", keptTicketIds: selectedTicketIds }
+                  )
+                }
+              />
+            ) : null}
           </div>
         </main>
       </div>
@@ -542,35 +570,6 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
           playerName={activePlayer.name}
           onAdvance={() => applyAction({ type: "advance_turn" })}
           onReady={() => setVisibility("visible")}
-        />
-      ) : null}
-
-      {pendingTickets.length > 0 && visibility === "visible" && !isCurrentPlayerLocalBot ? (
-        <TicketChoiceSheet
-          title={game.phase === "initialTickets" ? `${activePlayer.name}, choose starting tickets` : `${activePlayer.name}, keep new tickets`}
-          subtitle={
-            game.phase === "initialTickets"
-              ? "Keep at least two. Anything you return is gone for this game."
-              : "Keep at least one. This counts as your full turn."
-          }
-          tickets={pendingTickets}
-          config={localMap}
-          minimumKeep={game.phase === "initialTickets" ? 2 : 1}
-          selectedIds={selectedTicketIds}
-          focusedTicketId={focusedTicket?.id ?? null}
-          onFocusTicket={setFocusedTicket}
-          onToggle={(ticketId) =>
-            setSelectedTicketIds((current) =>
-              current.includes(ticketId) ? current.filter((id) => id !== ticketId) : [...current, ticketId]
-            )
-          }
-          onConfirm={() =>
-            applyAction(
-              game.phase === "initialTickets"
-                ? { type: "select_initial_tickets", keptTicketIds: selectedTicketIds }
-                : { type: "keep_drawn_tickets", keptTicketIds: selectedTicketIds }
-            )
-          }
         />
       ) : null}
 

--- a/apps/web/src/components/screens/LocalPlayScreen.tsx
+++ b/apps/web/src/components/screens/LocalPlayScreen.tsx
@@ -85,6 +85,8 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
   const [notifications, setNotifications] = useState<GameplayNotification[]>([]);
   const notificationIdRef = useRef(0);
+  const [turnStartedAt, setTurnStartedAt] = useState<number>(() => Date.now());
+  const [nowMs, setNowMs] = useState<number>(() => Date.now());
   const localMap = useMemo(() => getHudsonHustleMapByConfigId(localConfigId), [localConfigId]);
   const localVisuals = useMemo(() => getHudsonHustleVisualsByConfigId(localConfigId), [localConfigId]);
 
@@ -93,6 +95,22 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
     window.localStorage.setItem(LOCAL_SAVE_KEY, JSON.stringify(game));
     setHasSavedGame(true);
   }, [game]);
+
+  // Reset turn timer when active player changes
+  useEffect(() => {
+    setTurnStartedAt(Date.now());
+  }, [game?.activePlayerIndex, game?.phase]);
+
+  // Tick once per second to drive timer display
+  useEffect(() => {
+    if (!game || localTurnTimeLimitSeconds <= 0) return;
+    const interval = window.setInterval(() => setNowMs(Date.now()), 1000);
+    return () => window.clearInterval(interval);
+  }, [game, localTurnTimeLimitSeconds]);
+
+  const liveTimerSecondsRemaining = localTurnTimeLimitSeconds > 0
+    ? Math.max(0, Math.ceil(localTurnTimeLimitSeconds - (nowMs - turnStartedAt) / 1000))
+    : null;
 
   function pushNotification(message: string, tone: GameplayNotification["tone"] = "neutral") {
     notificationIdRef.current += 1;
@@ -360,7 +378,7 @@ export function LocalPlayScreen({ onReturnToGateway }: LocalPlayScreenProps): JS
     <div className="app-shell app-shell--gameplay-hud" data-config-theme={localVisuals.theme}>
       <header className="topbar topbar--gameplay-actions">
         <div className="topbar-private-spacer" aria-hidden="true" />
-        <TurnIndicator playerName={game.players[game.activePlayerIndex]?.name ?? ""} />
+        <TurnIndicator playerName={game.players[game.activePlayerIndex]?.name ?? ""} secondsRemaining={liveTimerSecondsRemaining} />
         <div className="topbar-actions">
           <Button className="topbar-icon-btn" aria-label="Guide" onClick={() => setGuideOpen(true)} data-label="Guide">?</Button>
           <ScoreGuide className="score-guide--subtle topbar-icon-btn" label="★" tooltipLabel="Score" />

--- a/apps/web/src/components/ui/game/BoardMap.tsx
+++ b/apps/web/src/components/ui/game/BoardMap.tsx
@@ -158,8 +158,8 @@ interface BoardMapProps {
   selectedRouteId: string | null;
   selectedCityId: string | null;
   highlightedCityIds?: string[];
-  onSelectRoute: (routeId: string) => void;
-  onSelectCity: (cityId: string) => void;
+  onSelectRoute: (routeId: string, position?: { x: number; y: number }) => void;
+  onSelectCity: (cityId: string, position?: { x: number; y: number }) => void;
 }
 
 export function BoardMap({
@@ -391,7 +391,7 @@ export function BoardMap({
                 stroke="transparent"
                 strokeWidth="28"
                 strokeLinecap="round"
-                onClick={() => onSelectRoute(route.id)}
+                onClick={(event) => onSelectRoute(route.id, { x: event.clientX, y: event.clientY })}
                 className="route-hitbox"
                 data-testid={`route-hitbox-${route.id}`}
                 fill="none"
@@ -424,7 +424,7 @@ export function BoardMap({
                 fill="#f8f5ef"
                 stroke="#453221"
                 strokeWidth="3"
-                onClick={() => onSelectCity(city.id)}
+                onClick={(event) => onSelectCity(city.id, { x: event.clientX, y: event.clientY })}
                 className="city-hitbox"
               />
               <circle cx={city.x} cy={city.y} r={selected ? 7 : 5} fill="#5b4633" opacity="0.85" />

--- a/apps/web/src/components/ui/game/ChatPanel.tsx
+++ b/apps/web/src/components/ui/game/ChatPanel.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import { FormField } from "../primitives/FormField";
+import { Panel } from "../primitives/Panel";
+import { SectionHeader } from "../primitives/SectionHeader";
+
+interface ChatMessage {
+  id: string;
+  playerName: string;
+  message: string;
+}
+
+interface ChatPanelProps {
+  messages?: ChatMessage[];
+  onSendMessage?: (message: string) => void;
+  className?: string;
+}
+
+export function ChatPanel({ messages = [], onSendMessage, className = "" }: ChatPanelProps): JSX.Element {
+  const [draft, setDraft] = useState("");
+
+  return (
+    <Panel variant="info" className={["chat-panel-dock", className].filter(Boolean).join(" ")}>
+      <form
+        className="chat-panel"
+        onSubmit={(event) => {
+          event.preventDefault();
+          const message = draft.trim();
+          if (!message || !onSendMessage) return;
+          onSendMessage(message);
+          setDraft("");
+        }}
+      >
+        <SectionHeader title="Chat" variant="compact" />
+        <div className="chat-panel__messages" aria-label="Chat messages">
+          {messages.length > 0 ? (
+            messages.map((msg) => (
+              <p key={msg.id} className="chat-panel__message">
+                <strong>{msg.playerName}</strong>
+                <span>{msg.message}</span>
+              </p>
+            ))
+          ) : (
+            <p className="chat-panel__message chat-panel__message--system">
+              {onSendMessage ? "No messages yet." : "Local play — no chat."}
+            </p>
+          )}
+        </div>
+        {onSendMessage ? (
+          <FormField as="div" label="Message" className="chat-panel__composer">
+            <input
+              type="text"
+              placeholder="Message room"
+              value={draft}
+              maxLength={280}
+              onChange={(event) => setDraft(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && draft.trim().length > 0) {
+                  event.preventDefault();
+                  onSendMessage(draft.trim());
+                  setDraft("");
+                }
+              }}
+            />
+          </FormField>
+        ) : null}
+      </form>
+    </Panel>
+  );
+}

--- a/apps/web/src/components/ui/game/ChatPanel.tsx
+++ b/apps/web/src/components/ui/game/ChatPanel.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { FormField } from "../primitives/FormField";
 import { Panel } from "../primitives/Panel";
 import { SectionHeader } from "../primitives/SectionHeader";
 
@@ -46,10 +45,11 @@ export function ChatPanel({ messages = [], onSendMessage, className = "" }: Chat
           )}
         </div>
         {onSendMessage ? (
-          <FormField as="div" label="Message" className="chat-panel__composer">
+          <div className="chat-panel__composer">
             <input
               type="text"
               placeholder="Message room"
+              aria-label="Message"
               value={draft}
               maxLength={280}
               onChange={(event) => setDraft(event.target.value)}
@@ -61,7 +61,7 @@ export function ChatPanel({ messages = [], onSendMessage, className = "" }: Chat
                 }
               }}
             />
-          </FormField>
+          </div>
         ) : null}
       </form>
     </Panel>

--- a/apps/web/src/components/ui/game/ChatPanel.tsx
+++ b/apps/web/src/components/ui/game/ChatPanel.tsx
@@ -19,7 +19,7 @@ export function ChatPanel({ messages = [], onSendMessage, className = "" }: Chat
   const [draft, setDraft] = useState("");
 
   return (
-    <Panel variant="info" className={["chat-panel-dock", className].filter(Boolean).join(" ")}>
+    <Panel variant="private" className={["chat-panel-dock", className].filter(Boolean).join(" ")}>
       <form
         className="chat-panel"
         onSubmit={(event) => {

--- a/apps/web/src/components/ui/game/ChatPanel.tsx
+++ b/apps/web/src/components/ui/game/ChatPanel.tsx
@@ -34,8 +34,7 @@ export function ChatPanel({ messages = [], onSendMessage, className = "" }: Chat
           {messages.length > 0 ? (
             messages.map((msg) => (
               <p key={msg.id} className="chat-panel__message">
-                <strong>{msg.playerName}</strong>
-                <span>{msg.message}</span>
+                <strong>{msg.playerName}:</strong> <span>{msg.message}</span>
               </p>
             ))
           ) : (

--- a/apps/web/src/components/ui/game/FloatingBuildPanel.tsx
+++ b/apps/web/src/components/ui/game/FloatingBuildPanel.tsx
@@ -1,15 +1,53 @@
-import type { ReactNode } from "react";
-import { Button } from "../primitives/Button";
+import { useLayoutEffect, useRef, useState, type ReactNode } from "react";
 
 interface FloatingBuildPanelProps {
   children: ReactNode;
   onClose: () => void;
+  anchor?: { x: number; y: number } | null;
   className?: string;
 }
 
-export function FloatingBuildPanel({ children, onClose, className = "" }: FloatingBuildPanelProps): JSX.Element {
+const PANEL_WIDTH = 280;
+const PANEL_OFFSET = 16;
+const VIEWPORT_PAD = 12;
+
+export function FloatingBuildPanel({ children, onClose, anchor = null, className = "" }: FloatingBuildPanelProps): JSX.Element {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+
+  useLayoutEffect(() => {
+    if (!anchor || !ref.current) {
+      setPos(null);
+      return;
+    }
+    const rect = ref.current.getBoundingClientRect();
+    const w = rect.width || PANEL_WIDTH;
+    const h = rect.height || 200;
+    let left = anchor.x + PANEL_OFFSET;
+    let top = anchor.y + PANEL_OFFSET;
+    if (left + w + VIEWPORT_PAD > window.innerWidth) {
+      left = anchor.x - w - PANEL_OFFSET;
+    }
+    if (top + h + VIEWPORT_PAD > window.innerHeight) {
+      top = anchor.y - h - PANEL_OFFSET;
+    }
+    left = Math.max(VIEWPORT_PAD, Math.min(left, window.innerWidth - w - VIEWPORT_PAD));
+    top = Math.max(VIEWPORT_PAD, Math.min(top, window.innerHeight - h - VIEWPORT_PAD));
+    setPos({ top, left });
+  }, [anchor?.x, anchor?.y]);
+
+  const style: React.CSSProperties = pos
+    ? { position: "fixed", top: pos.top, left: pos.left, width: PANEL_WIDTH }
+    : {};
+
   return (
-    <div className={["floating-build-panel", className].filter(Boolean).join(" ")} role="dialog" aria-label="Build options">
+    <div
+      ref={ref}
+      className={["floating-build-panel", className].filter(Boolean).join(" ")}
+      role="dialog"
+      aria-label="Build options"
+      style={style}
+    >
       <button
         type="button"
         className="floating-build-panel__close"

--- a/apps/web/src/components/ui/game/FloatingBuildPanel.tsx
+++ b/apps/web/src/components/ui/game/FloatingBuildPanel.tsx
@@ -7,7 +7,7 @@ interface FloatingBuildPanelProps {
   className?: string;
 }
 
-const PANEL_WIDTH = 280;
+const PANEL_WIDTH = 340;
 const PANEL_OFFSET = 16;
 const VIEWPORT_PAD = 12;
 

--- a/apps/web/src/components/ui/game/FloatingBuildPanel.tsx
+++ b/apps/web/src/components/ui/game/FloatingBuildPanel.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+import { Button } from "../primitives/Button";
+
+interface FloatingBuildPanelProps {
+  children: ReactNode;
+  onClose: () => void;
+  className?: string;
+}
+
+export function FloatingBuildPanel({ children, onClose, className = "" }: FloatingBuildPanelProps): JSX.Element {
+  return (
+    <div className={["floating-build-panel", className].filter(Boolean).join(" ")} role="dialog" aria-label="Build options">
+      <button
+        type="button"
+        className="floating-build-panel__close"
+        aria-label="Close build panel"
+        onClick={onClose}
+      >
+        ✕
+      </button>
+      <div className="floating-build-panel__body">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/game/PlayerHandPanel.tsx
+++ b/apps/web/src/components/ui/game/PlayerHandPanel.tsx
@@ -101,7 +101,7 @@ export function TicketDock({
   drawTicketsDisabled = false,
   className = ""
 }: TicketDockProps): JSX.Element {
-  const pageSize = 4;
+  const pageSize = 3;
   const [pageIndex, setPageIndex] = useState(0);
   const sortedTickets = useMemo(
     () => [...ticketProgress].sort((left, right) => Number(left.completed) - Number(right.completed)),

--- a/apps/web/src/components/ui/game/PlayerHandPanel.tsx
+++ b/apps/web/src/components/ui/game/PlayerHandPanel.tsx
@@ -141,13 +141,12 @@ export function TicketDock({
             fromLabel={getCityName(config, ticket.from)}
             toLabel={getCityName(config, ticket.to)}
             points={ticket.points}
-            status={completed ? "connected" : pinnedTicketId === ticket.id ? "keep" : "open"}
-            focused={focusedTicketId === ticket.id || pinnedTicketId === ticket.id}
+            status={completed ? "connected" : "open"}
+            focused={focusedTicketId === ticket.id}
             onMouseEnter={() => onFocusTicket?.(ticket)}
             onMouseLeave={() => onFocusTicket?.(null)}
             onFocus={() => onFocusTicket?.(ticket)}
             onBlur={() => onFocusTicket?.(null)}
-            onClick={() => onTogglePinnedTicket?.(ticket)}
           />
         ))}
         {Array.from({ length: Math.max(0, pageSize - visibleTickets.length) }, (_, index) => (

--- a/apps/web/src/components/ui/game/PlayerHandPanel.tsx
+++ b/apps/web/src/components/ui/game/PlayerHandPanel.tsx
@@ -141,7 +141,7 @@ export function TicketDock({
             fromLabel={getCityName(config, ticket.from)}
             toLabel={getCityName(config, ticket.to)}
             points={ticket.points}
-            status={completed ? "connected" : "open"}
+            status={completed ? "connected" : pinnedTicketId === ticket.id ? "keep" : "open"}
             focused={focusedTicketId === ticket.id || pinnedTicketId === ticket.id}
             onMouseEnter={() => onFocusTicket?.(ticket)}
             onMouseLeave={() => onFocusTicket?.(null)}

--- a/apps/web/src/components/ui/game/PlayerHandPanel.tsx
+++ b/apps/web/src/components/ui/game/PlayerHandPanel.tsx
@@ -85,6 +85,8 @@ interface TicketDockProps {
   pinnedTicketId?: string | null;
   onFocusTicket?: (ticket: TicketDef | null) => void;
   onTogglePinnedTicket?: (ticket: TicketDef) => void;
+  onDrawTickets?: () => void;
+  drawTicketsDisabled?: boolean;
   className?: string;
 }
 
@@ -95,6 +97,8 @@ export function TicketDock({
   pinnedTicketId = null,
   onFocusTicket,
   onTogglePinnedTicket,
+  onDrawTickets,
+  drawTicketsDisabled = false,
   className = ""
 }: TicketDockProps): JSX.Element {
   const pageSize = 4;
@@ -153,6 +157,15 @@ export function TicketDock({
           <div key={`ticket-placeholder-${index}`} className="ticket-row ticket-row--placeholder" aria-hidden="true" />
         ))}
       </div>
+      {onDrawTickets ? (
+        <Button
+          className="ticket-dock__draw"
+          disabled={drawTicketsDisabled}
+          onClick={onDrawTickets}
+        >
+          Draw tickets
+        </Button>
+      ) : null}
     </Panel>
   );
 }

--- a/apps/web/src/components/ui/game/PlayerRosterPanel.tsx
+++ b/apps/web/src/components/ui/game/PlayerRosterPanel.tsx
@@ -37,7 +37,7 @@ export function PlayerRoster({ players, activePlayerIndex, playerPalette, timer 
   const timerLabel = timer?.activePlayerIndex === activePlayerIndex ? formatRosterTimer(timer.secondsRemaining) : null;
 
   return (
-    <Panel variant="info" className={["player-roster", className].filter(Boolean).join(" ")}>
+    <Panel variant="private" className={["player-roster", className].filter(Boolean).join(" ")}>
       <div className="scoreboard player-roster__list">
         {rosterSlots.map((player, index) => {
           const isActive = index === activePlayerIndex;

--- a/apps/web/src/components/ui/game/ScoreGuide.tsx
+++ b/apps/web/src/components/ui/game/ScoreGuide.tsx
@@ -4,6 +4,7 @@ import { Button } from "../primitives/Button";
 interface ScoreGuideProps {
   className?: string;
   label?: string;
+  tooltipLabel?: string;
 }
 
 const routePointRows = [
@@ -15,13 +16,13 @@ const routePointRows = [
   "6 trains = 15 points"
 ];
 
-export function ScoreGuide({ className, label = "Scoring" }: ScoreGuideProps): JSX.Element {
+export function ScoreGuide({ className, label = "Scoring", tooltipLabel }: ScoreGuideProps): JSX.Element {
   const panelId = useId();
   const classes = ["score-guide", className].filter(Boolean).join(" ");
 
   return (
     <div className={classes}>
-      <Button className="score-guide__trigger" aria-describedby={panelId}>
+      <Button className="score-guide__trigger" aria-describedby={panelId} aria-label={tooltipLabel ?? label} data-label={tooltipLabel}>
         {label}
       </Button>
       <div id={panelId} className="score-guide__panel" role="note">

--- a/apps/web/src/components/ui/game/TicketSlip.tsx
+++ b/apps/web/src/components/ui/game/TicketSlip.tsx
@@ -17,7 +17,7 @@ function formatStatus(status: TicketSlipStatus): string {
     case "keep":
       return "Kept";
     case "review":
-      return "Hold";
+      return "";
     case "open":
     default:
       return "Open";

--- a/apps/web/src/components/ui/game/index.ts
+++ b/apps/web/src/components/ui/game/index.ts
@@ -1,4 +1,5 @@
 export { BoardMap } from "./BoardMap";
+export { ChatPanel } from "./ChatPanel";
 export { BoardStage } from "./BoardStage";
 export { CardSlot, formatCardLabel } from "./CardSlot";
 export type { CardSlotProps } from "./CardSlot";

--- a/apps/web/src/components/ui/game/index.ts
+++ b/apps/web/src/components/ui/game/index.ts
@@ -1,5 +1,6 @@
 export { BoardMap } from "./BoardMap";
 export { ChatPanel } from "./ChatPanel";
+export { FloatingBuildPanel } from "./FloatingBuildPanel";
 export { BoardStage } from "./BoardStage";
 export { CardSlot, formatCardLabel } from "./CardSlot";
 export type { CardSlotProps } from "./CardSlot";

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -1153,20 +1153,42 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
   justify-content: center;
 }
 
-/* Floating build popup on the map */
+/* Floating build popup — anchored to clicked route/city via inline style.
+   Falls back to fixed center if no anchor provided. */
 .floating-build-panel {
-  position: absolute;
-  bottom: var(--space-stack-md, 16px);
-  left: var(--space-stack-md, 16px);
-  width: clamp(240px, 28%, 300px);
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 280px;
   background:
-    radial-gradient(circle at top left, rgba(142, 169, 188, 0.14), transparent 34%),
-    linear-gradient(180deg, rgba(28, 38, 48, 0.96), rgba(8, 13, 18, 0.97));
-  border: 1px solid rgba(var(--hud-brass-light-rgb), 0.24);
-  border-radius: var(--radius-panel);
-  padding: var(--space-stack-sm) var(--space-stack-md);
-  z-index: 10;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+    var(--hud-grain),
+    linear-gradient(180deg, rgba(37, 31, 23, 0.97), rgba(12, 10, 8, 0.97));
+  border: 1px solid color-mix(in srgb, var(--hud-brass) 52%, rgba(0, 0, 0, 0.34));
+  border-radius: var(--radius-sm);
+  padding: 14px 16px 14px 18px;
+  z-index: 800;
+  color: var(--hud-paper-bright, #fff8ea);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 235, 194, 0.1),
+    0 24px 48px rgba(0, 0, 0, 0.55);
+  animation: floating-build-rise 160ms var(--easing-standard, ease) both;
+}
+
+@keyframes floating-build-rise {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* Inline style overrides the centered fallback when anchor is set */
+.floating-build-panel[style*="position: fixed"][style*="top:"] {
+  transform: none;
+  animation: floating-build-rise-anchor 160ms var(--easing-standard, ease) both;
+}
+
+@keyframes floating-build-rise-anchor {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 .floating-build-panel__close {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -861,6 +861,28 @@
 
 .app-shell--gameplay-hud .game-over-layer__actions .system-button {
   width: 100%;
+  background: rgba(var(--hud-brass-light-rgb), 0.14) !important;
+  border: 1px solid rgba(var(--hud-brass-light-rgb), 0.4) !important;
+  color: var(--hud-paper-bright, #fff8ea) !important;
+  font-weight: 700;
+  font-size: var(--type-sm);
+}
+
+.app-shell--gameplay-hud .game-over-layer__actions .system-button:hover:not(:disabled) {
+  background: rgba(var(--hud-brass-light-rgb), 0.26) !important;
+  border-color: rgba(var(--hud-brass-light-rgb), 0.6) !important;
+}
+
+.app-shell--gameplay-hud .game-over-layer__actions .system-button[variant="primary"],
+.app-shell--gameplay-hud .game-over-layer__actions .system-button.primary-button {
+  background: linear-gradient(180deg, #d6c391, #8c713b) !important;
+  border-color: #8c713b !important;
+  color: #1a150e !important;
+}
+
+.app-shell--gameplay-hud .game-over-layer__actions .system-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .app-shell--gameplay-hud .game-over-layer .endgame-card {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -1,6 +1,6 @@
 /* Gameplay HUD type/layout convergence pass. Keep map labels untouched. */
 .app-shell--gameplay-hud {
-  padding: 0 14px 8px;
+  padding: 0 12px 6px;
   gap: 4px;
   font-size: var(--type-body);
   /* Lock to viewport so floating overlays (notifications, modals) never trigger page scroll */
@@ -17,7 +17,9 @@
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
   gap: 12px;
-  min-height: 28px;
+  height: 24px;
+  min-height: 24px;
+  max-height: 24px;
   margin: 0;
   padding: 0;
   position: relative;
@@ -639,31 +641,34 @@
 
 .app-shell--gameplay-hud .turn-indicator__name {
   font-family: var(--font-sans);
-  font-size: var(--type-body);
+  font-size: var(--type-sm);
   font-weight: 700;
   color: #fff8ea;
   letter-spacing: 0.02em;
+  line-height: 1;
 }
 
 .app-shell--gameplay-hud .turn-indicator__label {
   font-family: var(--font-body);
-  font-size: var(--type-xs);
+  font-size: 11px;
   color: rgba(var(--hud-paper-rgb), 0.6);
   text-transform: lowercase;
   letter-spacing: 0.04em;
+  line-height: 1;
 }
 
 .app-shell--gameplay-hud .turn-indicator__timer {
   font-family: var(--font-body);
-  font-size: var(--type-xs);
+  font-size: 11px;
   font-weight: 800;
   font-variant-numeric: tabular-nums;
   letter-spacing: 0.02em;
   color: rgba(var(--hud-paper-rgb), 0.92);
-  padding: 2px 8px;
+  padding: 1px 6px;
   border-radius: var(--radius-control);
   background: rgba(212, 79, 76, 0.15);
   border: 1px solid rgba(212, 79, 76, 0.3);
+  line-height: 1;
 }
 
 /* Per-seat timer in the scoreboard row */
@@ -686,16 +691,18 @@
 .app-shell--gameplay-hud .topbar-icon-btn.system-button,
 .app-shell--gameplay-hud .topbar-icon-btn .score-guide__trigger.system-button {
   position: relative;
-  width: 28px;
-  min-width: 28px;
-  height: 28px;
-  min-height: 28px;
+  width: 22px;
+  min-width: 22px;
+  height: 22px;
+  min-height: 22px;
   padding: 0;
-  font-size: var(--type-xs);
+  font-size: 11px;
+  line-height: 1;
   display: flex;
   align-items: center;
   justify-content: center;
   overflow: visible;
+  border-radius: var(--radius-control);
 }
 
 .app-shell--gameplay-hud .score-guide.topbar-icon-btn {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -1,6 +1,8 @@
 /* Gameplay HUD type/layout convergence pass. Keep map labels untouched. */
 .app-shell--gameplay-hud {
-  padding: 0 12px 6px;
+  padding: 2px 10px 6px;
+  display: flex;
+  flex-direction: column;
   gap: 4px;
   font-size: var(--type-body);
   /* Lock to viewport so floating overlays (notifications, modals) never trigger page scroll */
@@ -8,6 +10,12 @@
   min-height: 0;
   max-height: 100vh;
   overflow: hidden;
+}
+
+/* Game-layout fills remaining viewport */
+.app-shell--gameplay-hud .game-layout {
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 /* Topbar layout: 3-column grid — empty spacer | centered turn indicator | icon actions
@@ -20,10 +28,14 @@
   height: 24px;
   min-height: 24px;
   max-height: 24px;
-  margin: 0;
+  margin: 0 !important;
   padding: 0;
   position: relative;
   z-index: var(--z-modal);
+}
+
+.app-shell--gameplay-hud .topbar--gameplay-actions {
+  margin: 0 !important;
 }
 
 .app-shell--gameplay-hud .topbar-private-spacer {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -91,11 +91,45 @@
 
 .app-shell--gameplay-hud .private-hand-rail,
 .app-shell--gameplay-hud .ticket-dock,
-.app-shell--gameplay-hud .inspector-dock {
+.app-shell--gameplay-hud .inspector-dock,
+.app-shell--gameplay-hud .side-panel .player-roster,
+.app-shell--gameplay-hud .chat-panel-dock {
   background:
     radial-gradient(circle at top left, rgba(142, 169, 188, 0.12), transparent 34%),
     linear-gradient(180deg, rgba(30, 42, 51, 0.88), rgba(9, 15, 20, 0.9));
   border-color: rgba(var(--hud-brass-light-rgb), 0.18);
+}
+
+/* Side-panel player roster: dark seat tiles matching TicketDock */
+.app-shell--gameplay-hud .side-panel .player-roster .player-strip {
+  background:
+    linear-gradient(180deg, rgba(255, 247, 231, 0.055), rgba(255, 247, 231, 0.025));
+  border-color: rgba(var(--hud-brass-light-rgb), 0.18);
+  color: var(--hud-paper-bright, #fff8ea);
+  box-shadow: none;
+}
+
+.app-shell--gameplay-hud .side-panel .player-roster .player-strip--active {
+  border-color: rgba(var(--hud-brass-light-rgb), 0.48);
+  background:
+    linear-gradient(180deg, rgba(var(--hud-brass-light-rgb), 0.16), rgba(var(--hud-brass-light-rgb), 0.06));
+}
+
+.app-shell--gameplay-hud .side-panel .player-roster .row-object__title {
+  color: var(--hud-paper-bright, #fff8ea);
+}
+
+.app-shell--gameplay-hud .side-panel .player-roster .row-object__meta,
+.app-shell--gameplay-hud .side-panel .player-roster .row-object__stat {
+  color: rgba(var(--hud-paper-rgb), 0.66);
+}
+
+.app-shell--gameplay-hud .side-panel .player-roster__row--placeholder {
+  opacity: 0.42;
+}
+
+.app-shell--gameplay-hud .side-panel .player-roster__active-label {
+  display: none;
 }
 
 .app-shell--gameplay-hud .section-header__title {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -1033,32 +1033,39 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
   grid-column: 3;
 }
 
-/* Make market slots look IDENTICAL to hand slots — with color-tinted border + radial wash */
+/* Market slots styled identically to gameplay-hud hand slots: dark ticket card
+   with brass color stripe on the left edge, count and label centered. */
 .app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot {
   min-height: 0;
   height: 100%;
   display: grid;
   place-items: center;
   gap: 4px;
-  padding: 8px 6px;
+  padding: 8px 6px 8px 16px;
   position: relative;
+  isolation: isolate;
+  overflow: hidden;
   grid-template-rows: 28px 1fr;
-  border-radius: var(--radius-panel);
-  border: 2px solid color-mix(in srgb, var(--hand-slot-color) 70%, rgba(var(--border-warm-rgb), 0.24)) !important;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: var(--radius-ticket);
+  border-color: color-mix(in srgb, var(--hand-slot-color) 46%, var(--hud-brass-dark)) !important;
   background:
-    radial-gradient(circle at top left, color-mix(in srgb, var(--hand-slot-color) 38%, transparent), transparent 56%),
-    linear-gradient(180deg, rgba(255, 252, 246, 0.96), rgba(239, 228, 207, 0.88)) !important;
+    linear-gradient(90deg, color-mix(in srgb, var(--hand-slot-color) 46%, transparent) 0 10px, transparent 10px),
+    linear-gradient(180deg, rgba(232, 220, 194, 0.18), rgba(14, 19, 20, 0.1)),
+    var(--hud-grain),
+    linear-gradient(180deg, #272b2b, #111514) !important;
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.4),
-    0 5px 10px rgba(var(--shadow-warm-rgb), 0.08) !important;
+    inset 0 0 0 1px rgba(255, 244, 217, 0.08),
+    inset 0 -10px 18px rgba(0, 0, 0, 0.18),
+    0 5px 0 rgba(0, 0, 0, 0.2) !important;
   text-align: center;
-  color: var(--ink, #241d15);
+  color: var(--hud-paper-bright, #fff8ea) !important;
   cursor: pointer;
 }
 
 .app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot:hover:not(:disabled) {
-  border-color: color-mix(in srgb, var(--hand-slot-color) 90%, rgba(var(--accent-base-rgb), 0.34)) !important;
-  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--hand-slot-color) 78%, var(--hud-brass-dark)) !important;
 }
 
 .app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot__count {
@@ -1066,15 +1073,14 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
   place-items: center;
   min-width: 28px;
   min-height: 28px;
-  background: color-mix(in srgb, var(--hand-slot-color) 24%, rgba(255, 252, 246, 0.6)) !important;
-  border: 1px solid color-mix(in srgb, var(--hand-slot-color) 42%, transparent) !important;
-  border-radius: var(--radius-control);
-  color: var(--ink, #241d15) !important;
+  background: transparent !important;
+  border: none !important;
+  color: var(--hud-paper-bright, #fff8ea) !important;
   font-family: var(--font-display, var(--font-body));
   font-size: var(--type-md);
   font-weight: 900;
   line-height: 1;
-  text-shadow: none;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
 }
 
 .app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot__label {
@@ -1082,7 +1088,7 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
   font-weight: 700;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: rgba(36, 29, 21, 0.66);
+  color: rgba(var(--hud-paper-rgb), 0.6);
 }
 
 .app-shell--gameplay-hud .right-col .supply-dock--board .section-header {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -1,7 +1,7 @@
 /* Gameplay HUD type/layout convergence pass. Keep map labels untouched. */
 .app-shell--gameplay-hud {
-  padding: var(--space-stack-sm) 14px var(--space-stack-sm);
-  gap: var(--space-stack-sm);
+  padding: 4px 14px var(--space-stack-sm);
+  gap: var(--space-stack-xs, 4px);
   font-size: var(--type-body);
 }
 
@@ -12,7 +12,8 @@
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
   gap: 12px;
-  min-height: 40px;
+  min-height: 32px;
+  margin: 0;
   position: relative;
   z-index: var(--z-modal);
 }
@@ -626,12 +627,12 @@
 .app-shell--gameplay-hud .topbar-icon-btn.system-button,
 .app-shell--gameplay-hud .topbar-icon-btn .score-guide__trigger.system-button {
   position: relative;
-  width: 36px;
-  min-width: 36px;
-  height: 36px;
-  min-height: 36px;
+  width: 28px;
+  min-width: 28px;
+  height: 28px;
+  min-height: 28px;
   padding: 0;
-  font-size: var(--type-sm);
+  font-size: var(--type-xs);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -293,19 +293,22 @@
   gap: 4px;
 }
 
-/* Compact hand slots in the 1x9 strip — smaller than market slots */
+/* Hand slots in the 1x9 strip — larger fonts for better readability */
 .app-shell--gameplay-hud .private-hand-rail .hand-color-slot {
-  min-height: 60px;
-  height: 60px;
-  padding: 6px 4px;
+  min-height: 72px;
+  height: 72px;
+  padding: 8px 6px;
 }
 
 .app-shell--gameplay-hud .private-hand-rail .hand-color-slot__count {
-  font-size: var(--type-sm);
+  font-size: var(--type-lg);
+  font-weight: 900;
 }
 
 .app-shell--gameplay-hud .private-hand-rail .hand-color-slot__label {
-  font-size: var(--type-3xs);
+  font-size: var(--type-xs);
+  font-weight: 700;
+  letter-spacing: 0.06em;
 }
 
 .app-shell--gameplay-hud .inspector-dock .supply-dock__market {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -963,13 +963,6 @@
   min-width: 0;
 }
 
-.app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 6px;
-  margin: 0;
-}
-
 .app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot {
   min-height: 0;
   height: 100%;
@@ -982,11 +975,34 @@
   min-width: 0;
 }
 
-.app-shell--gameplay-hud .side-panel__draw-ticket.system-button {
+/* Unified Draw button style for both Ticket Dock and Supply Dock */
+.app-shell--gameplay-hud .ticket-dock__draw.system-button,
+.app-shell--gameplay-hud .supply-dock__draw-deck.system-button {
+  width: 100%;
   background: rgba(var(--hud-brass-light-rgb), 0.12);
-  border-color: rgba(var(--hud-brass-light-rgb), 0.28);
+  border: 1px solid rgba(var(--hud-brass-light-rgb), 0.32);
+  border-radius: var(--radius-sm);
   color: var(--hud-paper-bright);
+  font-family: var(--font-body);
   font-size: var(--type-xs);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: none;
+  min-height: 36px;
+  padding: 6px 12px;
+  transition: background var(--duration-fast, 100ms) ease, border-color var(--duration-fast, 100ms) ease;
+}
+
+.app-shell--gameplay-hud .ticket-dock__draw.system-button:hover:not(:disabled),
+.app-shell--gameplay-hud .supply-dock__draw-deck.system-button:hover:not(:disabled) {
+  background: rgba(var(--hud-brass-light-rgb), 0.22);
+  border-color: rgba(var(--hud-brass-light-rgb), 0.5);
+}
+
+.app-shell--gameplay-hud .ticket-dock__draw.system-button:disabled,
+.app-shell--gameplay-hud .supply-dock__draw-deck.system-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 /* Board map scales fluidly inside the gameplay HUD column;

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -3497,9 +3497,7 @@ border-color: rgba(232, 220, 194, 0.72);
 }
 .app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > :nth-child(5) {
   grid-row: 3 !important;
-  grid-column: 1 / span 2 !important;
-  max-width: 50%;
-  justify-self: center;
+  grid-column: 1 !important;
 }
 
 .app-shell--gameplay-hud .ticket-dock {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -3535,3 +3535,63 @@ border-color: rgba(232, 220, 194, 0.72);
   outline: none;
   border-color: rgba(var(--hud-brass-light-rgb), 0.5) !important;
 }
+
+/* Game-over board: high-contrast text on dark backdrop, single-column breakdown rows */
+.app-shell--gameplay-hud .game-over-layer .endgame-card,
+body:has(.app-shell--gameplay-hud) .game-over-layer .endgame-card {
+  background:
+    var(--hud-grain),
+    linear-gradient(180deg, rgba(37, 31, 23, 0.94), rgba(12, 10, 8, 0.94)) !important;
+  border: 1px solid color-mix(in srgb, var(--hud-brass) 42%, rgba(0, 0, 0, 0.34)) !important;
+  color: var(--hud-paper-bright, #fff8ea) !important;
+}
+
+.app-shell--gameplay-hud .game-over-layer .surface-card__title,
+.app-shell--gameplay-hud .game-over-layer .surface-card__eyebrow,
+.app-shell--gameplay-hud .game-over-layer .endgame-score,
+.app-shell--gameplay-hud .game-over-layer .endgame-score__label,
+body:has(.app-shell--gameplay-hud) .game-over-layer .surface-card__title,
+body:has(.app-shell--gameplay-hud) .game-over-layer .surface-card__eyebrow,
+body:has(.app-shell--gameplay-hud) .game-over-layer .endgame-score,
+body:has(.app-shell--gameplay-hud) .game-over-layer .endgame-score__label {
+  color: var(--hud-paper-bright, #fff8ea) !important;
+}
+
+/* Single-column breakdown rows: label stacked above value */
+.app-shell--gameplay-hud .game-over-layer .endgame-breakdown__row,
+body:has(.app-shell--gameplay-hud) .game-over-layer .endgame-breakdown__row {
+  grid-template-columns: minmax(0, 1fr) !important;
+  gap: 4px !important;
+}
+
+.app-shell--gameplay-hud .game-over-layer .endgame-breakdown__label,
+body:has(.app-shell--gameplay-hud) .game-over-layer .endgame-breakdown__label {
+  color: rgba(var(--hud-brass-light-rgb), 0.78) !important;
+  font-size: var(--type-2xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.app-shell--gameplay-hud .game-over-layer .endgame-breakdown__value,
+body:has(.app-shell--gameplay-hud) .game-over-layer .endgame-breakdown__value {
+  color: var(--hud-paper-bright, #fff8ea) !important;
+  text-align: left !important;
+}
+
+.app-shell--gameplay-hud .game-over-layer .endgame-breakdown__list,
+body:has(.app-shell--gameplay-hud) .game-over-layer .endgame-breakdown__list {
+  padding-left: 0 !important;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.app-shell--gameplay-hud .game-over-layer .endgame-breakdown__list-item,
+body:has(.app-shell--gameplay-hud) .game-over-layer .endgame-breakdown__list-item {
+  color: var(--hud-paper-bright, #fff8ea) !important;
+  font-weight: 600;
+  font-size: var(--type-xs);
+  padding-left: 8px;
+  border-left: 2px solid rgba(var(--hud-brass-light-rgb), 0.5);
+}

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -3716,3 +3716,39 @@ body:has(.app-shell--gameplay-hud) .game-over-layer .endgame-breakdown__list-ite
   padding-left: 8px;
   border-left: 2px solid rgba(var(--hud-brass-light-rgb), 0.5);
 }
+
+/* ─── Final aggressive reset for floating-build-panel internals ───────────
+   Strip every chrome layer applied by base/HUD rules so the popup is one
+   clean dark card with no nested boxes. */
+.floating-build-panel .detail-card,
+.floating-build-panel .surface-card,
+.app-shell--gameplay-hud .floating-build-panel .detail-card,
+.app-shell--gameplay-hud .floating-build-panel .surface-card {
+  all: unset;
+  display: block;
+  color: var(--hud-paper-bright, #fff8ea);
+}
+
+.floating-build-panel .detail-card__decision-shelf,
+.app-shell--gameplay-hud .floating-build-panel .detail-card__decision-shelf {
+  all: unset;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  box-shadow: none;
+}
+
+.floating-build-panel .detail-card__decision-shelf::before,
+.floating-build-panel .detail-card__decision-shelf::after,
+.app-shell--gameplay-hud .floating-build-panel .detail-card__decision-shelf::before,
+.app-shell--gameplay-hud .floating-build-panel .detail-card__decision-shelf::after {
+  content: none !important;
+  display: none !important;
+  border: none !important;
+  background: none !important;
+}

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -847,15 +847,11 @@
   pointer-events: none;
 }
 
-/* Gameplay HUD layout overrides */
-.app-shell--gameplay-hud {
-  --game-right-rail: clamp(288px, 22vw, 340px);
-}
-
+/* Gameplay HUD layout overrides — rail widths defined in layout.css on .game-layout */
 
 .app-shell--gameplay-hud .board-column {
   grid-template-columns: minmax(0, 1fr) var(--game-right-rail);
-  align-items: start;
+  align-items: stretch;
 }
 
 /* right-col is a transparent column container; ChatPanel and SupplyDock
@@ -1736,9 +1732,8 @@
   stroke-width: 30px;
 }
 
-/* Gameplay HUD correction pass: translucent map, tighter right rail, equal cards, and calmer type. */
+/* Gameplay HUD correction pass: translucent map, equal cards, and calmer type. */
 .app-shell--gameplay-hud {
-  --game-right-rail: clamp(342px, 23.5vw, 378px);
   --hud-type-label: 0.67rem;
   --hud-type-small: 0.76rem;
   --hud-type-body: 0.9rem;

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -768,6 +768,56 @@
   font-size: var(--type-xs);
 }
 
+/* Floating build popup on the map */
+.floating-build-panel {
+  position: absolute;
+  bottom: var(--space-stack-md, 16px);
+  left: var(--space-stack-md, 16px);
+  width: clamp(240px, 28%, 300px);
+  background:
+    radial-gradient(circle at top left, rgba(142, 169, 188, 0.14), transparent 34%),
+    linear-gradient(180deg, rgba(28, 38, 48, 0.96), rgba(8, 13, 18, 0.97));
+  border: 1px solid rgba(var(--hud-brass-light-rgb), 0.24);
+  border-radius: var(--radius-panel);
+  padding: var(--space-stack-sm) var(--space-stack-md);
+  z-index: 10;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+.floating-build-panel__close {
+  position: absolute;
+  top: var(--space-stack-xs, 4px);
+  right: var(--space-stack-xs, 4px);
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid rgba(var(--hud-brass-light-rgb), 0.16);
+  border-radius: var(--radius-control);
+  color: rgba(var(--hud-paper-rgb), 0.6);
+  font-size: var(--type-xs);
+  cursor: pointer;
+  transition: color var(--duration-fast, 100ms) ease, border-color var(--duration-fast, 100ms) ease;
+}
+
+.floating-build-panel__close:hover {
+  color: var(--hud-paper-bright);
+  border-color: rgba(var(--hud-brass-light-rgb), 0.36);
+}
+
+.floating-build-panel__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-stack-sm, 8px);
+}
+
+/* Board stage must be position:relative for the floating panel to anchor */
+.board-stage {
+  position: relative;
+}
+
 .app-shell--gameplay-hud .inspector-dock {
   grid-template-columns: minmax(0, 1fr) 42px;
   column-gap: 12px;

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -2546,18 +2546,7 @@ border-color: rgba(232, 220, 194, 0.72);
 }
 
 
-.app-shell--gameplay-hud .player-roster,
-.app-shell--gameplay-hud .private-hand-rail,
-.app-shell--gameplay-hud .ticket-dock,
-.app-shell--gameplay-hud .inspector-dock {
-  border-color: rgba(var(--hud-brass-light-rgb), 0.2);
-  background:
-    linear-gradient(180deg, rgba(24, 34, 43, 0.82), rgba(12, 18, 24, 0.76));
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.1),
-    0 18px 48px rgba(0, 0, 0, 0.28);
-  color: var(--hud-paper-bright);
-}
+/* (Older translucent-blue panel rule removed — unified brass treatment applied above) */
 
 .app-shell--gameplay-hud .board-stage {
   border-color: rgba(var(--hud-brass-light-rgb), 0.22);
@@ -3334,3 +3323,24 @@ border-color: rgba(232, 220, 194, 0.72);
   color: rgba(255, 248, 232, 0.7);
 }
 
+
+/* ─── Final unified panel treatment ───────────────────────────────────────
+   All five in-game container panels — roster, ticket dock, hand rail, chat,
+   market — render with the same dark brass envelope so they read as one set. */
+.app-shell--gameplay-hud .side-panel .player-roster,
+.app-shell--gameplay-hud .ticket-dock,
+.app-shell--gameplay-hud .private-hand-rail,
+.app-shell--gameplay-hud .chat-panel-dock,
+.app-shell--gameplay-hud .right-col .supply-dock--board {
+  border: 1px solid color-mix(in srgb, var(--hud-brass) 42%, rgba(0, 0, 0, 0.34));
+  border-radius: var(--radius-sm);
+  background:
+    var(--hud-grain),
+    linear-gradient(180deg, rgba(37, 31, 23, 0.94), rgba(12, 10, 8, 0.94));
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 235, 194, 0.08),
+    inset 0 10px 18px rgba(255, 235, 194, 0.035),
+    0 18px 36px var(--hud-shadow);
+  color: var(--hud-paper-bright);
+  backdrop-filter: none;
+}

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -1035,70 +1035,23 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
 
 /* Market slots styled identically to gameplay-hud hand slots: dark ticket card
    with brass color stripe on the left edge, count and label centered. */
+/* Right-col market slot uses the unified hand-slot styling defined below.
+   Only layout-specific tweaks here. */
 .app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot {
   min-height: 0;
   height: 100%;
+  padding: 8px 6px 8px 16px;
   display: grid;
   place-items: center;
   gap: 4px;
-  padding: 8px 6px 8px 16px;
+  grid-template-rows: auto 1fr;
   position: relative;
-  isolation: isolate;
-  overflow: hidden;
-  grid-template-rows: 28px 1fr;
-  border-width: 1px;
-  border-style: solid;
-  border-radius: var(--radius-ticket);
-  border-color: color-mix(in srgb, var(--hand-slot-color) 46%, var(--hud-brass-dark)) !important;
-  background:
-    linear-gradient(90deg, color-mix(in srgb, var(--hand-slot-color) 46%, transparent) 0 10px, transparent 10px),
-    linear-gradient(180deg, rgba(232, 220, 194, 0.18), rgba(14, 19, 20, 0.1)),
-    var(--hud-grain),
-    linear-gradient(180deg, #272b2b, #111514) !important;
-  box-shadow:
-    inset 0 0 0 1px rgba(255, 244, 217, 0.08),
-    inset 0 -10px 18px rgba(0, 0, 0, 0.18),
-    0 5px 0 rgba(0, 0, 0, 0.2) !important;
   text-align: center;
-  color: var(--hud-paper-bright, #fff8ea) !important;
   cursor: pointer;
-}
-
-.app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot:hover:not(:disabled) {
-  border-color: color-mix(in srgb, var(--hand-slot-color) 78%, var(--hud-brass-dark)) !important;
-}
-
-.app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot__count {
-  display: grid;
-  place-items: center;
-  min-width: 28px;
-  min-height: 28px;
-  background: transparent !important;
-  border: none !important;
-  color: var(--hud-paper-bright, #fff8ea) !important;
-  font-family: var(--font-display, var(--font-body));
-  font-size: var(--type-md);
-  font-weight: 900;
-  line-height: 1;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
-}
-
-.app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot__label {
-  font-size: var(--type-3xs);
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: rgba(var(--hud-paper-rgb), 0.6);
 }
 
 .app-shell--gameplay-hud .right-col .supply-dock--board .section-header {
   min-width: 0;
-}
-
-.app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot {
-  min-height: 0;
-  height: 100%;
-  padding: 6px 4px;
 }
 
 .app-shell--gameplay-hud .right-col .supply-dock--board .system-button {
@@ -1334,7 +1287,8 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
 }
 
 .app-shell--gameplay-hud .hand-color-slot,
-.app-shell--gameplay-hud .inspector-dock .market-color-slot {
+.app-shell--gameplay-hud .inspector-dock .market-color-slot,
+.app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot {
   isolation: isolate;
   overflow: hidden;
   border-width: 1px;
@@ -1351,7 +1305,8 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
     0 5px 0 rgba(0, 0, 0, 0.2);
 }
 
-.app-shell--gameplay-hud .hand-color-slot::before {
+.app-shell--gameplay-hud .hand-color-slot::before,
+.app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot::before {
   content: "";
   position: absolute;
   inset: 7px 7px 6px 16px;
@@ -1363,8 +1318,9 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
     linear-gradient(180deg, rgba(232, 220, 194, 0.045), transparent);
 }
 
-.app-shell--gameplay-hud .market-color-slot::before,
-.app-shell--gameplay-hud .market-color-slot::after {
+/* Old inspector-dock market still uses display:none for ::before/::after */
+.app-shell--gameplay-hud .inspector-dock .market-color-slot::before,
+.app-shell--gameplay-hud .inspector-dock .market-color-slot::after {
   display: none !important;
   content: none !important;
 }
@@ -2328,6 +2284,11 @@ border-color: rgba(232, 220, 194, 0.72);
   word-wrap: break-word;
 }
 
+.app-shell--gameplay-hud .chat-panel__message strong,
+.app-shell--gameplay-hud .chat-panel__message span {
+  display: inline !important;
+}
+
 .app-shell--gameplay-hud .chat-panel__message strong {
   font-family: var(--font-body);
   font-size: var(--type-xs);
@@ -2335,7 +2296,7 @@ border-color: rgba(232, 220, 194, 0.72);
   letter-spacing: 0;
   text-transform: none;
   color: var(--hud-paper-bright, #fff8ea);
-  margin-right: 4px;
+  margin: 0 4px 0 0;
 }
 
 .app-shell--gameplay-hud .chat-panel__message--system {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -3202,7 +3202,7 @@ border-color: rgba(232, 220, 194, 0.72);
 
 .app-shell--gameplay-hud .ticket-dock__scroll {
   min-height: 0;
-  grid-template-rows: repeat(4, minmax(0, 1fr));
+  grid-template-rows: repeat(3, minmax(0, 1fr));
 }
 
 .app-shell--gameplay-hud .ticket-row {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -1,9 +1,9 @@
 /* Gameplay HUD type/layout convergence pass. Keep map labels untouched. */
 .app-shell--gameplay-hud {
-  padding: 2px 10px 6px;
+  padding: 0 10px 6px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
   font-size: var(--type-body);
   /* Lock to viewport so floating overlays (notifications, modals) never trigger page scroll */
   height: 100vh;

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -123,10 +123,10 @@
   grid-template-rows: repeat(4, 1fr);
 }
 
-/* Chat panel height matches roster height */
+/* Chat panel fills top half of right column */
 .app-shell--gameplay-hud .right-col .chat-panel-dock {
-  flex-shrink: 0;
-  height: var(--roster-height);
+  height: 100%;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -863,11 +863,10 @@
 }
 
 /* right-col is a transparent column container; ChatPanel and SupplyDock
-   each render their own dark panel — both children fill the full column width
-   and should not visually merge. */
+   each render their own dark panel — each fills its grid row. */
 .app-shell--gameplay-hud .right-col > * {
-  flex: 0 0 auto;
   width: 100%;
+  min-height: 0;
   box-sizing: border-box;
 }
 
@@ -882,9 +881,11 @@
     radial-gradient(circle at top left, rgba(142, 169, 188, 0.12), transparent 34%),
     linear-gradient(180deg, rgba(30, 42, 51, 0.88), rgba(9, 15, 20, 0.9));
   border: 1px solid rgba(var(--hud-brass-light-rgb), 0.18);
-  height: var(--ticket-dock-height);
+  height: 100%;
+  min-height: 0;
   width: 100%;
   box-sizing: border-box;
+  overflow: hidden;
 }
 
 /* Market grid grows to fill panel; deck button stays at bottom */

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -2269,36 +2269,50 @@ border-color: rgba(232, 220, 194, 0.72);
   font-size: var(--type-xs) !important;
 }
 
-/* Chat panel: serif font, tighter corners */
+/* Chat panel — tight one-liner messages, scrollable list */
 .app-shell--gameplay-hud .chat-panel {
-  font-family: var(--font-serif);
-  gap: 8px;
+  font-family: var(--font-body);
+  gap: 6px;
 }
 
 .app-shell--gameplay-hud .chat-panel__messages {
   border-radius: var(--radius-xs);
-  border-color: rgba(183, 155, 97, 0.12);
-  background: rgba(255, 247, 231, 0.03);
-  padding: 10px;
+  border: none;
+  background: transparent;
+  padding: 4px 2px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 .app-shell--gameplay-hud .chat-panel__message {
-  border-radius: var(--radius-map-tile);
-  background: rgba(255, 247, 231, 0.05);
-  color: rgba(255, 248, 232, 0.72);
-  font-family: var(--font-serif);
-  font-size: var(--hud-type-sm);
-  line-height: var(--lh-relaxed);
-  padding: 6px 8px;
+  border-radius: 0;
+  background: transparent;
+  color: rgba(var(--hud-paper-rgb), 0.82);
+  font-family: var(--font-body);
+  font-size: var(--type-xs);
+  line-height: 1.4;
+  padding: 2px 4px;
+  margin: 0;
+  white-space: normal;
+  word-wrap: break-word;
 }
 
 .app-shell--gameplay-hud .chat-panel__message strong {
-  font-family: var(--font-sans);
-  font-size: var(--hud-type-label);
-  font-weight: var(--weight-bold);
-  letter-spacing: var(--ls-wide);
-  text-transform: uppercase;
-  color: rgba(255, 248, 232, 0.88);
+  font-family: var(--font-body);
+  font-size: var(--type-xs);
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--hud-paper-bright, #fff8ea);
+  margin-right: 4px;
+}
+
+.app-shell--gameplay-hud .chat-panel__message--system {
+  color: rgba(var(--hud-paper-rgb), 0.4);
+  font-style: italic;
+  text-align: center;
+  padding: 8px 4px;
 }
 
 .app-shell--gameplay-hud .chat-panel__composer {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -1182,6 +1182,8 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
   display: flex;
   flex-direction: column;
   gap: var(--space-stack-sm, 8px);
+  min-width: 0;
+  overflow: hidden;
 }
 
 /* Build popup typography overrides — smaller and tighter for the compact 280px card */
@@ -1197,12 +1199,15 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
 .floating-build-panel .surface-card__title,
 .floating-build-panel .detail-card__title {
   font-family: var(--font-display, var(--font-body));
-  font-size: var(--type-md) !important;
+  font-size: var(--type-sm) !important;
   font-weight: 800 !important;
   line-height: 1.2 !important;
   color: var(--hud-paper-bright, #fff8ea) !important;
   margin: 0 0 8px !important;
   letter-spacing: 0;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  padding-right: 28px;
 }
 
 .floating-build-panel .detail-card__summary {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -3,6 +3,11 @@
   padding: 0 14px 8px;
   gap: 4px;
   font-size: var(--type-body);
+  /* Lock to viewport so floating overlays (notifications, modals) never trigger page scroll */
+  height: 100vh;
+  min-height: 0;
+  max-height: 100vh;
+  overflow: hidden;
 }
 
 /* Topbar layout: 3-column grid — empty spacer | centered turn indicator | icon actions

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -433,13 +433,16 @@
   white-space: normal;
 }
 
-/* TicketChoiceSheet: exact same size as inspector dock, solid background */
+/* Right-col is the positioning anchor for the ticket choice overlay */
+.app-shell--gameplay-hud .right-col {
+  position: relative;
+}
+
+/* TicketChoiceSheet: covers the right column (chat + market) when shown */
 .app-shell--gameplay-hud .ticket-choice-sheet {
   position: absolute !important;
-  top: 86px !important;
-  right: 18px !important;
-  bottom: 18px !important;
-  width: var(--game-right-rail) !important;
+  inset: 0 !important;
+  width: auto !important;
   max-height: none !important;
   pointer-events: auto !important;
   z-index: 35;

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -978,11 +978,10 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
   overflow: hidden;
 }
 
-/* Market: 3+2 row layout using two explicit grid rows.
-   Row 1 = 3 columns (cards 1-3), Row 2 = 2 columns centered (cards 4-5). */
+/* Market: 3 + 2 layout, RIGHT-aligned, cards rendered with hand-slot square shape */
 .app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market {
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
+  grid-template-columns: repeat(3, 1fr);
   grid-template-rows: 1fr 1fr;
   gap: 6px;
   flex: 1 1 auto;
@@ -990,31 +989,57 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
   margin: 0;
 }
 
-/* Row 1: cards 1, 2, 3 — each spans 2 of 6 columns */
+/* Row 1: cards 1, 2, 3 fill the row */
 .app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > :nth-child(1) {
   grid-row: 1;
-  grid-column: 1 / span 2;
+  grid-column: 1;
 }
 
 .app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > :nth-child(2) {
   grid-row: 1;
-  grid-column: 3 / span 2;
+  grid-column: 2;
 }
 
 .app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > :nth-child(3) {
   grid-row: 1;
-  grid-column: 5 / span 2;
+  grid-column: 3;
 }
 
-/* Row 2: cards 4, 5 — centered, each spans 2 columns */
+/* Row 2: cards 4, 5 — right-aligned (columns 2 and 3) */
 .app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > :nth-child(4) {
   grid-row: 2;
-  grid-column: 2 / span 2;
+  grid-column: 2;
 }
 
 .app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > :nth-child(5) {
   grid-row: 2;
-  grid-column: 4 / span 2;
+  grid-column: 3;
+}
+
+/* Square market slots styled like hand slots */
+.app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot {
+  display: grid;
+  grid-template-rows: auto auto;
+  align-items: center;
+  justify-items: center;
+  gap: 4px;
+  padding: 6px 4px;
+  min-height: 0;
+  height: 100%;
+  aspect-ratio: auto;
+  border-radius: var(--radius-control);
+  background: rgba(255, 247, 231, 0.04);
+  border: 1px solid rgba(var(--hud-brass-light-rgb), 0.18);
+}
+
+.app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot__count {
+  font-size: var(--type-sm);
+  font-weight: 800;
+}
+
+.app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot__label {
+  font-size: var(--type-3xs);
+  letter-spacing: 0.04em;
 }
 
 .app-shell--gameplay-hud .right-col .supply-dock--board .section-header {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -1011,30 +1011,54 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
   grid-column: 3;
 }
 
-/* Square market slots styled like hand slots */
+/* Make market slots look IDENTICAL to hand slots */
 .app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot {
-  display: grid;
-  grid-template-rows: auto auto;
-  align-items: center;
-  justify-items: center;
-  gap: 4px;
-  padding: 6px 4px;
   min-height: 0;
   height: 100%;
-  aspect-ratio: auto;
-  border-radius: var(--radius-control);
-  background: rgba(255, 247, 231, 0.04);
-  border: 1px solid rgba(var(--hud-brass-light-rgb), 0.18);
+  display: grid;
+  place-items: center;
+  gap: 4px;
+  padding: 8px 6px;
+  position: relative;
+  grid-template-rows: 28px 1fr;
+  border-radius: var(--radius-panel);
+  border: 1px solid color-mix(in srgb, var(--hand-slot-color) 42%, rgba(var(--border-warm-rgb), 0.24));
+  background:
+    radial-gradient(circle at top left, color-mix(in srgb, var(--hand-slot-color) 24%, transparent), transparent 52%),
+    linear-gradient(180deg, rgba(255, 252, 246, 0.92), rgba(239, 228, 207, 0.82));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.4),
+    0 5px 10px rgba(var(--shadow-warm-rgb), 0.06);
+  text-align: center;
+  color: var(--ink, #241d15);
+  cursor: pointer;
+}
+
+.app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--hand-slot-color) 60%, rgba(var(--accent-base-rgb), 0.34));
 }
 
 .app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot__count {
-  font-size: var(--type-sm);
-  font-weight: 800;
+  display: grid;
+  place-items: center;
+  min-width: 28px;
+  min-height: 28px;
+  background: transparent;
+  border-radius: var(--radius-control);
+  color: var(--ink, #241d15);
+  font-family: var(--font-display, var(--font-body));
+  font-size: var(--type-md);
+  font-weight: 900;
+  line-height: 1;
+  text-shadow: none;
 }
 
 .app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot__label {
   font-size: var(--type-3xs);
-  letter-spacing: 0.04em;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(36, 29, 21, 0.66);
 }
 
 .app-shell--gameplay-hud .right-col .supply-dock--board .section-header {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -5,19 +5,24 @@
   font-size: var(--type-body);
 }
 
-/* Topbar layout: 3-column grid — left spacer | turn indicator | action buttons */
+/* Topbar layout: 3-column grid — empty spacer | centered turn indicator | icon actions
+   Symmetric layout so turn indicator stays in the middle of the viewport. */
 .app-shell--gameplay-hud .topbar {
   display: grid;
-  grid-template-columns: var(--game-left-rail) minmax(0, 1fr) auto;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
   gap: 12px;
-  min-height: 56px;
-  justify-items: stretch;
+  min-height: 40px;
   position: relative;
   z-index: var(--z-modal);
 }
 
+.app-shell--gameplay-hud .topbar-private-spacer {
+  grid-column: 1;
+}
+
 .app-shell--gameplay-hud .topbar-actions {
+  grid-column: 3;
   display: flex;
   align-items: center;
   justify-content: flex-end;
@@ -443,7 +448,8 @@
 
 /* Gameplay HUD visual refinement. Rail widths defined in layout.css on .game-layout. */
 .app-shell--gameplay-hud {
-  padding-top: 6px;
+  padding-top: 4px;
+  gap: var(--space-stack-xs, 4px);
 }
 
 .app-shell--gameplay-hud .topbar-private-spacer {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -3350,13 +3350,16 @@ border-color: rgba(232, 220, 194, 0.72);
 
 
 /* ─── Final unified panel treatment ───────────────────────────────────────
-   All five in-game container panels — roster, ticket dock, hand rail, chat,
-   market — render with the same dark brass envelope so they read as one set. */
+   All in-game container panels — roster, ticket dock, hand rail, chat,
+   market, plus the privacy "hidden" panel during handoff — render with the
+   same dark brass envelope so they read as one set. */
 .app-shell--gameplay-hud .side-panel .player-roster,
 .app-shell--gameplay-hud .ticket-dock,
 .app-shell--gameplay-hud .private-hand-rail,
 .app-shell--gameplay-hud .chat-panel-dock,
-.app-shell--gameplay-hud .right-col .supply-dock--board {
+.app-shell--gameplay-hud .right-col .supply-dock--board,
+.app-shell--gameplay-hud .hidden-panel,
+.app-shell--gameplay-hud .side-panel .panel--danger {
   border: 1px solid color-mix(in srgb, var(--hud-brass) 42%, rgba(0, 0, 0, 0.34));
   border-radius: var(--radius-sm);
   background:
@@ -3368,4 +3371,13 @@ border-color: rgba(232, 220, 194, 0.72);
     0 18px 36px var(--hud-shadow);
   color: var(--hud-paper-bright);
   backdrop-filter: none;
+}
+
+.app-shell--gameplay-hud .hidden-panel p,
+.app-shell--gameplay-hud .hidden-panel .section-header__title {
+  color: rgba(var(--hud-paper-rgb), 0.82);
+}
+
+.app-shell--gameplay-hud .hidden-panel .section-header__eyebrow {
+  color: rgba(var(--hud-brass-light-rgb), 0.82);
 }

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -738,17 +738,34 @@
   pointer-events: none;
 }
 
-/* Right rail overflow fix: reserve a real tab spine instead of letting tabs crowd content. */
+/* Gameplay HUD layout overrides */
 .app-shell--gameplay-hud {
-  --game-right-rail: clamp(376px, 28vw, 424px);
+  --game-right-rail: clamp(288px, 22vw, 340px);
 }
 
 .app-shell--gameplay-hud .topbar {
-  grid-template-columns: var(--game-left-rail) minmax(0, 1fr) var(--game-right-rail);
+  grid-template-columns: var(--game-left-rail) minmax(0, 1fr) auto;
 }
 
 .app-shell--gameplay-hud .board-column {
   grid-template-columns: minmax(0, 1fr) var(--game-right-rail);
+  align-items: start;
+}
+
+.app-shell--gameplay-hud .right-col {
+  background:
+    radial-gradient(circle at top left, rgba(142, 169, 188, 0.12), transparent 34%),
+    linear-gradient(180deg, rgba(30, 42, 51, 0.88), rgba(9, 15, 20, 0.9));
+  border: 1px solid rgba(var(--hud-brass-light-rgb), 0.18);
+  border-radius: var(--radius-panel);
+  padding: var(--space-stack-sm);
+}
+
+.app-shell--gameplay-hud .side-panel__draw-ticket.system-button {
+  background: rgba(var(--hud-brass-light-rgb), 0.12);
+  border-color: rgba(var(--hud-brass-light-rgb), 0.28);
+  color: var(--hud-paper-bright);
+  font-size: var(--type-xs);
 }
 
 .app-shell--gameplay-hud .inspector-dock {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -538,28 +538,36 @@
   position: relative;
 }
 
-.app-shell--gameplay-hud .topbar-icon-btn.system-button::after {
+/* Hover tooltip rendered as ::after pseudo on the button itself.
+   Positioned BELOW the button (top: calc(100% + 6px)) so it doesn't get clipped
+   by the viewport top edge. */
+.app-shell--gameplay-hud .topbar-icon-btn.system-button::after,
+.app-shell--gameplay-hud .topbar-icon-btn .score-guide__trigger.system-button::after {
   content: attr(data-label);
   position: absolute;
-  bottom: calc(100% + 6px);
+  top: calc(100% + 6px);
   left: 50%;
   transform: translateX(-50%);
   white-space: nowrap;
   font-size: var(--type-xs);
   font-family: var(--font-body);
   font-weight: 600;
-  color: var(--color-ink-strong);
-  background: var(--color-canvas-base);
-  border: 1px solid var(--color-border-subtle);
+  letter-spacing: 0.02em;
+  color: var(--hud-paper-bright, #fff8ea);
+  background: rgba(11, 17, 22, 0.94);
+  border: 1px solid rgba(var(--hud-brass-light-rgb), 0.24);
   border-radius: var(--radius-control);
-  padding: 3px 8px;
+  padding: 4px 10px;
   pointer-events: none;
   opacity: 0;
+  z-index: 200;
   transition: opacity var(--duration-fast, 100ms) ease;
 }
 
 .app-shell--gameplay-hud .topbar-icon-btn.system-button:hover::after,
-.app-shell--gameplay-hud .topbar-icon-btn.system-button:focus-visible::after {
+.app-shell--gameplay-hud .topbar-icon-btn.system-button:focus-visible::after,
+.app-shell--gameplay-hud .topbar-icon-btn .score-guide__trigger.system-button:hover::after,
+.app-shell--gameplay-hud .topbar-icon-btn .score-guide__trigger.system-button:focus-visible::after {
   opacity: 1;
 }
 

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -625,11 +625,6 @@
 }
 
 /* Gameplay HUD visual refinement. Rail widths defined in layout.css on .game-layout. */
-.app-shell--gameplay-hud {
-  padding-top: 4px;
-  gap: var(--space-stack-xs, 4px);
-}
-
 .app-shell--gameplay-hud .topbar-private-spacer {
   min-width: 0;
 }
@@ -2911,15 +2906,7 @@ border-color: rgba(232, 220, 194, 0.72);
   font-size: var(--type-map);
 }
 
-.app-shell--gameplay-hud {
-  height: 100vh;
-  min-height: 0;
-  display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
-  gap: 10px;
-  overflow: hidden;
-  font-size: var(--type-body);
-}
+/* Layout definition lives at the top of this file (flex column with 0 gap). */
 
 
 .gameplay-brand {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -829,6 +829,42 @@
   flex: 0 0 auto;
 }
 
+/* Right-column SupplyDock layout: vertical stack with market as 2×3 grid */
+.app-shell--gameplay-hud .right-col .supply-dock--board {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-stack-sm, 8px);
+  padding: var(--space-stack-sm) var(--space-stack-md);
+  border-radius: var(--radius-panel);
+  background:
+    radial-gradient(circle at top left, rgba(142, 169, 188, 0.12), transparent 34%),
+    linear-gradient(180deg, rgba(30, 42, 51, 0.88), rgba(9, 15, 20, 0.9));
+  border: 1px solid rgba(var(--hud-brass-light-rgb), 0.18);
+}
+
+.app-shell--gameplay-hud .right-col .supply-dock--board .section-header {
+  min-width: 0;
+}
+
+.app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
+  margin: 0;
+}
+
+.app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot {
+  min-height: 70px;
+  height: 70px;
+  padding: 8px 6px;
+}
+
+.app-shell--gameplay-hud .right-col .supply-dock--board .system-button {
+  width: 100%;
+  min-height: 44px;
+  min-width: 0;
+}
+
 .app-shell--gameplay-hud .side-panel__draw-ticket.system-button {
   background: rgba(var(--hud-brass-light-rgb), 0.12);
   border-color: rgba(var(--hud-brass-light-rgb), 0.28);

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -2582,13 +2582,7 @@ border-color: rgba(232, 220, 194, 0.72);
   z-index: 1;
 }
 
-.app-shell--gameplay-hud .board-column {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(280px, 292px);
-  grid-template-rows: auto minmax(0, 1fr);
-  gap: 14px;
-  min-width: 0;
-}
+/* (Old hardcoded board-column override removed — width comes from --game-right-rail) */
 
 .app-shell--gameplay-hud .board-stage {
   grid-column: 1;

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -100,6 +100,23 @@
   border-color: rgba(var(--hud-brass-light-rgb), 0.18);
 }
 
+/* Side-panel player roster: fixed sizing to fit exactly 4 seat tiles */
+.app-shell--gameplay-hud .side-panel .player-roster {
+  flex-shrink: 0;
+  gap: var(--space-stack-xs, 4px);
+}
+
+.app-shell--gameplay-hud .side-panel .player-roster__list,
+.app-shell--gameplay-hud .side-panel .player-roster .scoreboard {
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-stack-xs, 4px);
+}
+
+.app-shell--gameplay-hud .side-panel .player-roster .player-strip {
+  min-height: 44px;
+  padding: 6px 8px;
+}
+
 /* Side-panel player roster: dark seat tiles matching TicketDock */
 .app-shell--gameplay-hud .side-panel .player-roster .player-strip {
   background:

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -1218,6 +1218,13 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
   margin: 0 !important;
 }
 
+.floating-build-panel .surface-card__header,
+.floating-build-panel .surface-card__row {
+  margin: 0 !important;
+  padding: 0 !important;
+  text-indent: 0 !important;
+}
+
 .floating-build-panel .surface-card__title,
 .floating-build-panel .detail-card__title {
   font-family: var(--font-display, var(--font-body));
@@ -1226,10 +1233,11 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
   line-height: 1.2 !important;
   color: var(--hud-paper-bright, #fff8ea) !important;
   margin: 0 0 8px !important;
+  padding: 0 28px 0 0 !important;
   letter-spacing: 0;
+  text-indent: 0 !important;
   white-space: normal;
   overflow-wrap: anywhere;
-  padding-right: 28px;
 }
 
 .floating-build-panel .detail-card__summary {
@@ -1268,6 +1276,15 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
 .floating-build-panel .detail-card__decision-shelf {
   gap: 6px !important;
   margin-top: 4px;
+  padding: 0 !important;
+  border: none !important;
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+.floating-build-panel .detail-card__decision-shelf::before {
+  display: none !important;
+  content: none !important;
 }
 
 .floating-build-panel .choice-chip-button {
@@ -3200,9 +3217,11 @@ border-color: rgba(232, 220, 194, 0.72);
   grid-template-rows: auto minmax(0, 1fr);
 }
 
+/* Preserve 4-row footprint even though only 3 tickets render per page —
+   creates extra breathing room between the 3rd ticket and the Draw Tickets button. */
 .app-shell--gameplay-hud .ticket-dock__scroll {
   min-height: 0;
-  grid-template-rows: repeat(3, minmax(0, 1fr));
+  grid-template-rows: repeat(4, minmax(0, 1fr));
 }
 
 .app-shell--gameplay-hud .ticket-row {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -3381,3 +3381,25 @@ border-color: rgba(232, 220, 194, 0.72);
 .app-shell--gameplay-hud .hidden-panel .section-header__eyebrow {
   color: rgba(var(--hud-brass-light-rgb), 0.82);
 }
+
+/* ─── Unify outer padding on the 3 bottom panels so their bottom edges land
+   at the same Y when columns are equal height. */
+.app-shell--gameplay-hud .ticket-dock,
+.app-shell--gameplay-hud .private-hand-rail,
+.app-shell--gameplay-hud .right-col .supply-dock--board {
+  padding: 10px 12px !important;
+  box-sizing: border-box;
+}
+
+/* Internal grids fill the panel area equally */
+.app-shell--gameplay-hud .right-col .supply-dock--board {
+  display: grid !important;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  gap: 6px;
+}
+
+.app-shell--gameplay-hud .ticket-dock {
+  display: grid !important;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  gap: 6px;
+}

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -100,10 +100,40 @@
   border-color: rgba(var(--hud-brass-light-rgb), 0.18);
 }
 
+/* Roster + chat heights are both bound to --roster-height so they always match.
+   4 seat tiles × 44px min-height + 3 gaps × 4px + panel padding ≈ 216px. */
+.app-shell--gameplay-hud {
+  --roster-height: 216px;
+  --ticket-dock-height: min(360px, 44vh);
+}
+
 /* Side-panel player roster: fixed sizing to fit exactly 4 seat tiles */
 .app-shell--gameplay-hud .side-panel .player-roster {
   flex-shrink: 0;
   gap: var(--space-stack-xs, 4px);
+  height: var(--roster-height);
+}
+
+/* Chat panel height matches roster height */
+.app-shell--gameplay-hud .right-col .chat-panel-dock {
+  flex-shrink: 0;
+  height: var(--roster-height);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.app-shell--gameplay-hud .right-col .chat-panel-dock .chat-panel {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.app-shell--gameplay-hud .right-col .chat-panel-dock .chat-panel__messages {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .app-shell--gameplay-hud .side-panel .player-roster__list,

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -154,6 +154,25 @@
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--hud-brass-light-rgb), 0.35) transparent;
+}
+
+.app-shell--gameplay-hud .right-col .chat-panel-dock .chat-panel__messages::-webkit-scrollbar {
+  width: 6px;
+}
+
+.app-shell--gameplay-hud .right-col .chat-panel-dock .chat-panel__messages::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.app-shell--gameplay-hud .right-col .chat-panel-dock .chat-panel__messages::-webkit-scrollbar-thumb {
+  background: rgba(var(--hud-brass-light-rgb), 0.32);
+  border-radius: 3px;
+}
+
+.app-shell--gameplay-hud .right-col .chat-panel-dock .chat-panel__messages::-webkit-scrollbar-thumb:hover {
+  background: rgba(var(--hud-brass-light-rgb), 0.5);
 }
 
 .app-shell--gameplay-hud .side-panel .player-roster__list,

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -672,7 +672,16 @@
 }
 
 .notification-pipe {
+  position: fixed;
+  bottom: var(--space-stack-lg, 24px);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-stack-xs, 4px);
   z-index: 160;
+  pointer-events: none;
 }
 
 /* Right rail overflow fix: reserve a real tab spine instead of letting tabs crowd content. */

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -774,11 +774,25 @@
   min-width: 0;
 }
 
+/* TicketDock fills the bottom half; layout: header / scroll / draw button */
 .app-shell--gameplay-hud .side-panel__bottom .ticket-dock {
   height: 100%;
   max-height: none;
   min-height: 0;
   overflow: hidden;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  gap: var(--space-stack-xs, 4px);
+}
+
+.app-shell--gameplay-hud .ticket-dock .ticket-dock__scroll {
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.app-shell--gameplay-hud .ticket-dock__draw {
+  width: 100%;
+  margin-top: 4px;
 }
 
 .app-shell--gameplay-hud .game-over-layer {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -1536,7 +1536,8 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
     linear-gradient(180deg, #211b14, #100d09);
 }
 
-/* Angular tabletop correction: avoid the repeated rounded-card silhouette. */
+/* (Old angular clip-path removed for visual consistency across panels.)
+   Disabled by overriding with `none` below. */
 .app-shell--gameplay-hud .private-hand-rail,
 .app-shell--gameplay-hud .ticket-dock,
 .app-shell--gameplay-hud .inspector-dock,
@@ -1544,7 +1545,12 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
 .app-shell--gameplay-hud .game-over-layer,
 .app-shell--gameplay-hud .leave-confirm-card,
 .app-shell--gameplay-hud .ticket-choice-sheet__panel {
-  border-radius: var(--radius-map-tile);
+  border-radius: var(--radius-sm) !important;
+  clip-path: none !important;
+}
+
+/* Original angular clip-path retained as reference but neutralised */
+.disabled-angular-panel {
   clip-path: polygon(
     10px 0,
     calc(100% - 10px) 0,
@@ -1557,11 +1563,13 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
   );
 }
 
+/* Inner-border decoration disabled — pseudo-element neutralised */
 .app-shell--gameplay-hud .private-hand-rail::after,
 .app-shell--gameplay-hud .ticket-dock::after,
 .app-shell--gameplay-hud .inspector-dock::after,
 .app-shell--gameplay-hud .player-roster--top::after {
-  content: "";
+  content: none !important;
+  display: none !important;
   pointer-events: none;
   position: absolute;
   inset: 7px;

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -746,8 +746,8 @@
 }
 
 .app-shell--gameplay-hud .ticket-dock {
-  height: min(360px, 44vh);
-  max-height: min(360px, 44vh);
+  height: var(--ticket-dock-height);
+  max-height: var(--ticket-dock-height);
 }
 
 .app-shell--gameplay-hud .game-over-layer {
@@ -858,9 +858,12 @@
 }
 
 /* right-col is a transparent column container; ChatPanel and SupplyDock
-   each render their own dark panel — they should not visually merge. */
+   each render their own dark panel — both children fill the full column width
+   and should not visually merge. */
 .app-shell--gameplay-hud .right-col > * {
   flex: 0 0 auto;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 /* Right-column SupplyDock layout: vertical stack with market as 2×3 grid */
@@ -874,6 +877,15 @@
     radial-gradient(circle at top left, rgba(142, 169, 188, 0.12), transparent 34%),
     linear-gradient(180deg, rgba(30, 42, 51, 0.88), rgba(9, 15, 20, 0.9));
   border: 1px solid rgba(var(--hud-brass-light-rgb), 0.18);
+  height: var(--ticket-dock-height);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* Market grid grows to fill panel; deck button stays at bottom */
+.app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market {
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .app-shell--gameplay-hud .right-col .supply-dock--board .section-header {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -1011,7 +1011,7 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
   grid-column: 3;
 }
 
-/* Make market slots look IDENTICAL to hand slots */
+/* Make market slots look IDENTICAL to hand slots — with color-tinted border + radial wash */
 .app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot {
   min-height: 0;
   height: 100%;
@@ -1022,20 +1022,21 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
   position: relative;
   grid-template-rows: 28px 1fr;
   border-radius: var(--radius-panel);
-  border: 1px solid color-mix(in srgb, var(--hand-slot-color) 42%, rgba(var(--border-warm-rgb), 0.24));
+  border: 2px solid color-mix(in srgb, var(--hand-slot-color) 70%, rgba(var(--border-warm-rgb), 0.24)) !important;
   background:
-    radial-gradient(circle at top left, color-mix(in srgb, var(--hand-slot-color) 24%, transparent), transparent 52%),
-    linear-gradient(180deg, rgba(255, 252, 246, 0.92), rgba(239, 228, 207, 0.82));
+    radial-gradient(circle at top left, color-mix(in srgb, var(--hand-slot-color) 38%, transparent), transparent 56%),
+    linear-gradient(180deg, rgba(255, 252, 246, 0.96), rgba(239, 228, 207, 0.88)) !important;
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.4),
-    0 5px 10px rgba(var(--shadow-warm-rgb), 0.06);
+    0 5px 10px rgba(var(--shadow-warm-rgb), 0.08) !important;
   text-align: center;
   color: var(--ink, #241d15);
   cursor: pointer;
 }
 
 .app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot:hover:not(:disabled) {
-  border-color: color-mix(in srgb, var(--hand-slot-color) 60%, rgba(var(--accent-base-rgb), 0.34));
+  border-color: color-mix(in srgb, var(--hand-slot-color) 90%, rgba(var(--accent-base-rgb), 0.34)) !important;
+  transform: translateY(-1px);
 }
 
 .app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot__count {
@@ -1043,9 +1044,10 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
   place-items: center;
   min-width: 28px;
   min-height: 28px;
-  background: transparent;
+  background: color-mix(in srgb, var(--hand-slot-color) 24%, rgba(255, 252, 246, 0.6)) !important;
+  border: 1px solid color-mix(in srgb, var(--hand-slot-color) 42%, transparent) !important;
   border-radius: var(--radius-control);
-  color: var(--ink, #241d15);
+  color: var(--ink, #241d15) !important;
   font-family: var(--font-display, var(--font-body));
   font-size: var(--type-md);
   font-weight: 900;

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -885,6 +885,45 @@
   border-color: #d45a3f !important;
 }
 
+/* All in-game modals (handoff, leave, draw-reveal): dark HUD treatment for contrast */
+.app-shell--gameplay-hud ~ .modal-shell .modal-shell__card,
+.app-shell--gameplay-hud .modal-shell .modal-shell__card,
+body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card {
+  background:
+    var(--hud-grain),
+    linear-gradient(180deg, rgba(37, 31, 23, 0.97), rgba(12, 10, 8, 0.97)) !important;
+  border: 1px solid color-mix(in srgb, var(--hud-brass) 48%, rgba(0, 0, 0, 0.4)) !important;
+  border-radius: var(--radius-sm) !important;
+  color: var(--hud-paper-bright, #fff8ea) !important;
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 235, 194, 0.08),
+    0 24px 48px rgba(0, 0, 0, 0.55) !important;
+}
+
+.app-shell--gameplay-hud .modal-shell .modal-shell__card p,
+body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card p {
+  color: rgba(var(--hud-paper-rgb), 0.78) !important;
+}
+
+.app-shell--gameplay-hud .modal-shell .modal-shell__card .section-header__eyebrow,
+body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .section-header__eyebrow {
+  color: rgba(var(--hud-brass-light-rgb), 0.82) !important;
+}
+
+.app-shell--gameplay-hud .modal-shell .modal-shell__card .section-header__title,
+body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .section-header__title {
+  color: var(--hud-paper-bright, #fff8ea) !important;
+}
+
+/* Primary action button in modals */
+.app-shell--gameplay-hud .modal-shell .modal-shell__card .system-button.primary-button,
+body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-button.primary-button {
+  background: linear-gradient(180deg, #d6c391, #8c713b) !important;
+  border-color: #8c713b !important;
+  color: #1a150e !important;
+  font-weight: 800;
+}
+
 .notification-pipe {
   position: fixed !important;
   bottom: var(--space-stack-lg, 24px) !important;

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -109,12 +109,18 @@
   --ticket-dock-height: min(360px, 44vh);
 }
 
-/* Side-panel player roster: fixed sizing to fit exactly 4 seat tiles */
+/* Side-panel player roster: fills top half of side-panel */
 .app-shell--gameplay-hud .side-panel .player-roster {
-  flex-shrink: 0;
+  height: 100%;
+  min-height: 0;
   gap: 0;
-  height: var(--roster-height);
   padding: 8px;
+  overflow: hidden;
+}
+
+.app-shell--gameplay-hud .side-panel .player-roster .scoreboard {
+  height: 100%;
+  grid-template-rows: repeat(4, 1fr);
 }
 
 /* Chat panel height matches roster height */
@@ -746,9 +752,11 @@
   min-width: 0;
 }
 
-.app-shell--gameplay-hud .ticket-dock {
-  height: var(--ticket-dock-height);
-  max-height: var(--ticket-dock-height);
+.app-shell--gameplay-hud .side-panel__bottom .ticket-dock {
+  height: 100%;
+  max-height: none;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .app-shell--gameplay-hud .game-over-layer {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -793,13 +793,10 @@
   align-items: start;
 }
 
-.app-shell--gameplay-hud .right-col {
-  background:
-    radial-gradient(circle at top left, rgba(142, 169, 188, 0.12), transparent 34%),
-    linear-gradient(180deg, rgba(30, 42, 51, 0.88), rgba(9, 15, 20, 0.9));
-  border: 1px solid rgba(var(--hud-brass-light-rgb), 0.18);
-  border-radius: var(--radius-panel);
-  padding: var(--space-stack-sm);
+/* right-col is a transparent column container; ChatPanel and SupplyDock
+   each render their own dark panel — they should not visually merge. */
+.app-shell--gameplay-hud .right-col > * {
+  flex: 0 0 auto;
 }
 
 .app-shell--gameplay-hud .side-panel__draw-ticket.system-button {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -888,10 +888,29 @@
   overflow: hidden;
 }
 
-/* Market grid grows to fill panel; deck button stays at bottom */
+/* Market grid: 6-col base, each card spans 2 cols, second row (items 4-5) is centered.
+   This gives a tidy 3+2 layout where the 2 bottom cards align under the 1st/2nd of top row. */
 .app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  grid-template-rows: 1fr 1fr;
+  gap: 6px;
   flex: 1 1 auto;
   min-height: 0;
+  align-content: stretch;
+  margin: 0;
+}
+
+.app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > * {
+  grid-column: span 2;
+}
+
+.app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > :nth-child(4) {
+  grid-column: 2 / span 2;
+}
+
+.app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > :nth-child(5) {
+  grid-column: 4 / span 2;
 }
 
 .app-shell--gameplay-hud .right-col .supply-dock--board .section-header {
@@ -906,9 +925,9 @@
 }
 
 .app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot {
-  min-height: 70px;
-  height: 70px;
-  padding: 8px 6px;
+  min-height: 0;
+  height: 100%;
+  padding: 6px 4px;
 }
 
 .app-shell--gameplay-hud .right-col .supply-dock--board .system-button {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -879,15 +879,15 @@
 }
 
 .notification-pipe {
-  position: fixed;
-  bottom: var(--space-stack-lg, 24px);
-  left: 50%;
-  transform: translateX(-50%);
+  position: fixed !important;
+  bottom: var(--space-stack-lg, 24px) !important;
+  left: 50% !important;
+  transform: translateX(-50%) !important;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: var(--space-stack-xs, 4px);
-  z-index: 160;
+  z-index: 9000 !important;
   pointer-events: none;
 }
 

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -3488,11 +3488,11 @@ border-color: rgba(232, 220, 194, 0.72);
   min-width: 0 !important;
 }
 
-/* Market inner grid: 3 columns × 2 rows. Cards 4-5 right-aligned (cols 2-3) */
+/* Market inner grid: 2 columns × 3 rows (2 + 2 + 1). 5th card centered alone in row 3. */
 .app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market {
   display: grid !important;
-  grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
-  grid-template-rows: 1fr 1fr !important;
+  grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  grid-template-rows: repeat(3, 1fr) !important;
   gap: 6px;
   min-height: 0;
 }
@@ -3506,16 +3506,18 @@ border-color: rgba(232, 220, 194, 0.72);
   grid-column: 2 !important;
 }
 .app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > :nth-child(3) {
-  grid-row: 1 !important;
-  grid-column: 3 !important;
+  grid-row: 2 !important;
+  grid-column: 1 !important;
 }
 .app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > :nth-child(4) {
   grid-row: 2 !important;
   grid-column: 2 !important;
 }
 .app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > :nth-child(5) {
-  grid-row: 2 !important;
-  grid-column: 3 !important;
+  grid-row: 3 !important;
+  grid-column: 1 / span 2 !important;
+  max-width: 50%;
+  justify-self: center;
 }
 
 .app-shell--gameplay-hud .ticket-dock {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -1146,7 +1146,7 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 280px;
+  width: 340px;
   background:
     var(--hud-grain),
     linear-gradient(180deg, rgba(37, 31, 23, 0.97), rgba(12, 10, 8, 0.97));
@@ -3572,7 +3572,7 @@ border-color: rgba(232, 220, 194, 0.72);
   display: grid !important;
   grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
   grid-template-rows: repeat(3, auto) !important;
-  gap: 6px;
+  gap: 12px;
   min-height: 0;
   align-content: start;
 }

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -452,7 +452,7 @@
 .app-shell--gameplay-hud .topbar {
   display: grid;
   grid-template-columns: var(--game-left-rail) minmax(0, 1fr) var(--game-right-rail);
-  align-items: stretch;
+  align-items: center;
   gap: 12px;
   min-height: 56px;
   justify-items: stretch;
@@ -473,9 +473,10 @@
 .app-shell--gameplay-hud .turn-indicator {
   grid-column: 2;
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 8px;
   justify-content: center;
+  align-self: center;
 }
 
 .app-shell--gameplay-hud .turn-indicator__name {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -918,8 +918,8 @@
   overflow: hidden;
 }
 
-/* Market grid: 6-col base, each card spans 2 cols, second row (items 4-5) is centered.
-   This gives a tidy 3+2 layout where the 2 bottom cards align under the 1st/2nd of top row. */
+/* Market: 3+2 row layout using two explicit grid rows.
+   Row 1 = 3 columns (cards 1-3), Row 2 = 2 columns centered (cards 4-5). */
 .app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market {
   display: grid;
   grid-template-columns: repeat(6, 1fr);
@@ -927,19 +927,33 @@
   gap: 6px;
   flex: 1 1 auto;
   min-height: 0;
-  align-content: stretch;
   margin: 0;
 }
 
-.app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > * {
-  grid-column: span 2;
+/* Row 1: cards 1, 2, 3 — each spans 2 of 6 columns */
+.app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > :nth-child(1) {
+  grid-row: 1;
+  grid-column: 1 / span 2;
 }
 
+.app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > :nth-child(2) {
+  grid-row: 1;
+  grid-column: 3 / span 2;
+}
+
+.app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > :nth-child(3) {
+  grid-row: 1;
+  grid-column: 5 / span 2;
+}
+
+/* Row 2: cards 4, 5 — centered, each spans 2 columns */
 .app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > :nth-child(4) {
+  grid-row: 2;
   grid-column: 2 / span 2;
 }
 
 .app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > :nth-child(5) {
+  grid-row: 2;
   grid-column: 4 / span 2;
 }
 

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -1184,6 +1184,77 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
   gap: var(--space-stack-sm, 8px);
 }
 
+/* Build popup typography overrides — smaller and tighter for the compact 280px card */
+.floating-build-panel .surface-card,
+.floating-build-panel .detail-card {
+  background: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+.floating-build-panel .surface-card__title,
+.floating-build-panel .detail-card__title {
+  font-family: var(--font-display, var(--font-body));
+  font-size: var(--type-md) !important;
+  font-weight: 800 !important;
+  line-height: 1.2 !important;
+  color: var(--hud-paper-bright, #fff8ea) !important;
+  margin: 0 0 8px !important;
+  letter-spacing: 0;
+}
+
+.floating-build-panel .detail-card__summary {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.floating-build-panel .detail-card__facts {
+  gap: 4px !important;
+}
+
+.floating-build-panel .detail-card__fact {
+  font-size: var(--type-2xs) !important;
+  padding: 3px 8px !important;
+  min-height: 22px !important;
+  border-radius: var(--radius-control) !important;
+  background: rgba(var(--hud-brass-light-rgb), 0.12) !important;
+  border-color: rgba(var(--hud-brass-light-rgb), 0.24) !important;
+  color: rgba(var(--hud-paper-rgb), 0.82) !important;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 700 !important;
+}
+
+.floating-build-panel .detail-card__prompt {
+  font-size: var(--type-xs) !important;
+  line-height: 1.3 !important;
+  font-weight: 500 !important;
+  color: rgba(var(--hud-paper-rgb), 0.82) !important;
+  margin: 4px 0 8px !important;
+  white-space: nowrap;
+}
+
+.floating-build-panel .detail-card__decision-shelf {
+  gap: 6px !important;
+  margin-top: 4px;
+}
+
+.floating-build-panel .choice-chip-button {
+  font-size: var(--type-xs) !important;
+  padding: 6px 12px !important;
+  min-height: 32px !important;
+}
+
+.floating-build-panel .muted-copy {
+  font-size: var(--type-xs);
+  color: rgba(var(--hud-paper-rgb), 0.5);
+  font-style: italic;
+}
+
 /* Board stage must be position:relative for the floating panel to anchor */
 .board-stage {
   position: relative;

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -102,17 +102,18 @@
 }
 
 /* Roster + chat heights are both bound to --roster-height so they always match.
-   4 seat tiles × 44px min-height + 3 gaps × 4px + panel padding ≈ 216px. */
+   4 seat tiles × 40px + 3 gaps × 4px + panel padding (16px) ≈ 188px. */
 .app-shell--gameplay-hud {
-  --roster-height: 216px;
+  --roster-height: 192px;
   --ticket-dock-height: min(360px, 44vh);
 }
 
 /* Side-panel player roster: fixed sizing to fit exactly 4 seat tiles */
 .app-shell--gameplay-hud .side-panel .player-roster {
   flex-shrink: 0;
-  gap: var(--space-stack-xs, 4px);
+  gap: 0;
   height: var(--roster-height);
+  padding: 8px;
 }
 
 /* Chat panel height matches roster height */
@@ -144,8 +145,37 @@
 }
 
 .app-shell--gameplay-hud .side-panel .player-roster .player-strip {
-  min-height: 44px;
-  padding: 6px 8px;
+  min-height: 40px;
+  height: 40px;
+  padding: 4px 8px;
+  grid-template-columns: 28px minmax(0, 1fr) auto;
+  gap: 6px 8px;
+}
+
+/* Tighter typography to fit 4 rows */
+.app-shell--gameplay-hud .side-panel .player-roster .row-object__title {
+  font-size: var(--type-xs);
+  font-weight: 800;
+  line-height: 1.1;
+}
+
+.app-shell--gameplay-hud .side-panel .player-roster .row-object__meta {
+  font-size: var(--type-2xs);
+  line-height: 1.1;
+}
+
+.app-shell--gameplay-hud .side-panel .player-roster .row-object__stat {
+  font-size: var(--type-2xs);
+  line-height: 1.1;
+}
+
+.app-shell--gameplay-hud .side-panel .player-roster .row-object__stats {
+  gap: 1px;
+}
+
+.app-shell--gameplay-hud .side-panel .player-roster .seat-avatar--tiny {
+  width: 28px;
+  height: 28px;
 }
 
 /* Side-panel player roster: dark seat tiles matching TicketDock */

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -24,10 +24,10 @@
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  gap: 12px;
-  height: 24px;
-  min-height: 24px;
-  max-height: 24px;
+  gap: 6px;
+  height: 12px;
+  min-height: 12px;
+  max-height: 12px;
   margin: 0 !important;
   padding: 0;
   position: relative;
@@ -3463,4 +3463,37 @@ border-color: rgba(232, 220, 194, 0.72);
   grid-template-columns: 1fr !important;
   grid-template-rows: auto minmax(0, 1fr) auto !important;
   gap: 6px;
+}
+
+/* Chat input: dark, compact, consistent with HUD panels */
+.app-shell--gameplay-hud .chat-panel-dock .chat-panel__composer {
+  display: block;
+  padding: 0;
+  margin: 0;
+}
+
+.app-shell--gameplay-hud .chat-panel-dock .chat-panel__composer input {
+  width: 100%;
+  box-sizing: border-box;
+  background: rgba(255, 247, 231, 0.04) !important;
+  border: 1px solid rgba(var(--hud-brass-light-rgb), 0.22) !important;
+  border-radius: var(--radius-control) !important;
+  color: var(--hud-paper-bright, #fff8ea) !important;
+  font-family: var(--font-body);
+  font-size: var(--type-xs);
+  font-style: normal;
+  padding: 6px 10px !important;
+  height: auto !important;
+  min-height: 0 !important;
+  box-shadow: none !important;
+}
+
+.app-shell--gameplay-hud .chat-panel-dock .chat-panel__composer input::placeholder {
+  color: rgba(var(--hud-paper-rgb), 0.4);
+  font-style: normal;
+}
+
+.app-shell--gameplay-hud .chat-panel-dock .chat-panel__composer input:focus-visible {
+  outline: none;
+  border-color: rgba(var(--hud-brass-light-rgb), 0.5) !important;
 }

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -3402,15 +3402,65 @@ border-color: rgba(232, 220, 194, 0.72);
   box-sizing: border-box;
 }
 
-/* Internal grids fill the panel area equally */
+/* Right-col SupplyDock — vertical stack: header / 3+2 market grid / draw button
+   Overrides the base `.supply-dock--board` horizontal grid layout from ui.css */
 .app-shell--gameplay-hud .right-col .supply-dock--board {
   display: grid !important;
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  grid-template-columns: 1fr !important;
+  grid-template-rows: auto minmax(0, 1fr) auto !important;
   gap: 6px;
+}
+
+.app-shell--gameplay-hud .right-col .supply-dock--board > .section-header {
+  grid-column: 1 !important;
+  grid-row: 1 !important;
+  min-width: 0 !important;
+}
+
+.app-shell--gameplay-hud .right-col .supply-dock--board > .supply-dock__market {
+  grid-column: 1 !important;
+  grid-row: 2 !important;
+}
+
+.app-shell--gameplay-hud .right-col .supply-dock--board > .system-button {
+  grid-column: 1 !important;
+  grid-row: 3 !important;
+  min-width: 0 !important;
+}
+
+/* Market inner grid: 3 columns × 2 rows. Cards 4-5 right-aligned (cols 2-3) */
+.app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market {
+  display: grid !important;
+  grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
+  grid-template-rows: 1fr 1fr !important;
+  gap: 6px;
+  min-height: 0;
+}
+
+.app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > :nth-child(1) {
+  grid-row: 1 !important;
+  grid-column: 1 !important;
+}
+.app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > :nth-child(2) {
+  grid-row: 1 !important;
+  grid-column: 2 !important;
+}
+.app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > :nth-child(3) {
+  grid-row: 1 !important;
+  grid-column: 3 !important;
+}
+.app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > :nth-child(4) {
+  grid-row: 2 !important;
+  grid-column: 2 !important;
+}
+.app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > :nth-child(5) {
+  grid-row: 2 !important;
+  grid-column: 3 !important;
 }
 
 .app-shell--gameplay-hud .ticket-dock {
   display: grid !important;
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  grid-template-columns: 1fr !important;
+  grid-template-rows: auto minmax(0, 1fr) auto !important;
   gap: 6px;
 }

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -520,10 +520,10 @@
 
 .app-shell--gameplay-hud .topbar-actions {
   grid-column: 3;
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  align-items: stretch;
-  gap: 7px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-stack-xs, 4px);
   width: 100%;
 }
 
@@ -546,6 +546,60 @@
   padding: 7px 8px;
   font-size: var(--type-xs);
   line-height: 1.04;
+}
+
+/* Icon-only topbar buttons: square, same height as turn indicator, label reveals on hover */
+.app-shell--gameplay-hud .topbar-icon-btn.system-button,
+.app-shell--gameplay-hud .topbar-icon-btn .score-guide__trigger.system-button {
+  position: relative;
+  width: 36px;
+  min-width: 36px;
+  height: 36px;
+  min-height: 36px;
+  padding: 0;
+  font-size: var(--type-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: visible;
+}
+
+.app-shell--gameplay-hud .score-guide.topbar-icon-btn {
+  position: relative;
+}
+
+.app-shell--gameplay-hud .topbar-icon-btn.system-button::after {
+  content: attr(data-label);
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  font-size: var(--type-xs);
+  font-family: var(--font-body);
+  font-weight: 600;
+  color: var(--color-ink-strong);
+  background: var(--color-canvas-base);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-control);
+  padding: 3px 8px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--duration-fast, 100ms) ease;
+}
+
+.app-shell--gameplay-hud .topbar-icon-btn.system-button:hover::after,
+.app-shell--gameplay-hud .topbar-icon-btn.system-button:focus-visible::after {
+  opacity: 1;
+}
+
+.app-shell--gameplay-hud .topbar-actions {
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.app-shell--gameplay-hud .topbar-icon-btn--leave.system-button {
+  color: var(--color-status-danger, #d45a3f);
 }
 
 /* .game-layout and .board-column grid structure lives in layout.css */

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -5,26 +5,23 @@
   font-size: var(--type-body);
 }
 
+/* Topbar layout: 3-column grid — left spacer | turn indicator | action buttons */
 .app-shell--gameplay-hud .topbar {
-  grid-template-columns: 1fr;
-  justify-items: end;
-  gap: 0;
-  min-height: var(--control-height-row);
-  margin: 0;
+  display: grid;
+  grid-template-columns: var(--game-left-rail) minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  min-height: 56px;
+  justify-items: stretch;
+  position: relative;
+  z-index: var(--z-modal);
 }
 
 .app-shell--gameplay-hud .topbar-actions {
+  display: flex;
+  align-items: center;
   justify-content: flex-end;
-  gap: var(--space-stack-sm);
-}
-
-.app-shell--gameplay-hud .topbar-actions .system-button,
-.app-shell--gameplay-hud .score-guide__trigger.system-button {
-  min-height: var(--control-height-compact);
-  min-width: var(--button-min-width-sm);
-  padding: 8px 13px;
-  font-size: var(--type-sm);
-  font-weight: 800;
+  gap: var(--space-stack-xs, 4px);
 }
 
 /* .game-layout and .board-column grid structure lives in layout.css */
@@ -449,15 +446,6 @@
   padding-top: 6px;
 }
 
-.app-shell--gameplay-hud .topbar {
-  display: grid;
-  grid-template-columns: var(--game-left-rail) minmax(0, 1fr) var(--game-right-rail);
-  align-items: center;
-  gap: 12px;
-  min-height: 56px;
-  justify-items: stretch;
-}
-
 .app-shell--gameplay-hud .topbar-private-spacer {
   min-width: 0;
 }
@@ -513,20 +501,6 @@
   font-variant-numeric: tabular-nums;
 }
 
-.app-shell--gameplay-hud .topbar {
-  position: relative;
-  z-index: var(--z-modal);
-}
-
-.app-shell--gameplay-hud .topbar-actions {
-  grid-column: 3;
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: var(--space-stack-xs, 4px);
-  width: 100%;
-}
-
 .app-shell--gameplay-hud .topbar-actions .score-guide {
   min-width: 0;
 }
@@ -536,16 +510,6 @@
   top: 72px !important;
   right: 18px !important;
   z-index: 9999 !important;
-}
-
-.app-shell--gameplay-hud .topbar-actions .system-button,
-.app-shell--gameplay-hud .topbar-actions .score-guide__trigger.system-button {
-  width: 100%;
-  min-width: 0;
-  min-height: 52px;
-  padding: 7px 8px;
-  font-size: var(--type-xs);
-  line-height: 1.04;
 }
 
 /* Icon-only topbar buttons: square, same height as turn indicator, label reveals on hover */
@@ -591,11 +555,6 @@
 .app-shell--gameplay-hud .topbar-icon-btn.system-button:hover::after,
 .app-shell--gameplay-hud .topbar-icon-btn.system-button:focus-visible::after {
   opacity: 1;
-}
-
-.app-shell--gameplay-hud .topbar-actions {
-  align-items: center;
-  justify-content: flex-end;
 }
 
 .app-shell--gameplay-hud .topbar-icon-btn--leave.system-button {
@@ -743,9 +702,6 @@
   --game-right-rail: clamp(288px, 22vw, 340px);
 }
 
-.app-shell--gameplay-hud .topbar {
-  grid-template-columns: var(--game-left-rail) minmax(0, 1fr) auto;
-}
 
 .app-shell--gameplay-hud .board-column {
   grid-template-columns: minmax(0, 1fr) var(--game-right-rail);
@@ -1415,11 +1371,6 @@
     linear-gradient(180deg, #29302d, #111613);
 }
 
-.app-shell--gameplay-hud .topbar .system-button,
-.app-shell--gameplay-hud .score-guide__trigger.system-button {
-  min-height: 48px;
-  font-size: var(--type-sm);
-}
 
 .app-shell--gameplay-hud .game-over-layer,
 .app-shell--gameplay-hud .leave-confirm-card,
@@ -1624,23 +1575,6 @@
   line-height: 1.26;
 }
 
-.app-shell--gameplay-hud .topbar-actions {
-  grid-template-columns: repeat(3, 1fr);
-}
-
-.app-shell--gameplay-hud .topbar-actions .score-guide {
-  width: 100%;
-}
-
-.app-shell--gameplay-hud .topbar-actions .system-button,
-.app-shell--gameplay-hud .topbar-actions .score-guide__trigger.system-button {
-  inline-size: 100%;
-  block-size: 52px;
-  min-block-size: 52px;
-  padding: 6px 7px;
-  font-size: var(--type-xs);
-  font-weight: 830;
-}
 
 .app-shell--gameplay-hud .score-guide {
   z-index: 600;
@@ -2225,13 +2159,6 @@ border-color: rgba(232, 220, 194, 0.72);
   position: relative;
   z-index: 1;
 }
-.app-shell--gameplay-hud .topbar {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: stretch;
-  gap: 14px;
-  margin-bottom: 12px;
-}
 
 .app-shell--gameplay-hud .board-column {
   display: grid;
@@ -2261,29 +2188,9 @@ border-color: rgba(232, 220, 194, 0.72);
   max-height: calc(100vh - 92px);
 }
 .app-shell--gameplay-hud .topbar--gameplay-actions {
-  min-height: 0;
-  justify-content: stretch;
+  min-height: 56px;
 }
 
-.app-shell--gameplay-hud .topbar-actions {
-  width: auto;
-  min-width: 0;
-  padding: 6px;
-  border: 1px solid rgba(var(--hud-brass-light-rgb), 0.18);
-  border-radius: var(--card-radius);
-  background: rgba(11, 17, 22, 0.64);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.1),
-    0 14px 40px rgba(0, 0, 0, 0.24);
-}
-
-.app-shell--gameplay-hud .topbar-actions .system-button,
-.app-shell--gameplay-hud .score-guide__trigger.system-button {
-  width: 108px;
-  min-width: 108px;
-  min-height: 50px;
-  padding-inline: 10px;
-}
 
 .app-shell--gameplay-hud .player-roster,
 .app-shell--gameplay-hud .private-hand-rail,
@@ -2646,9 +2553,6 @@ border-color: rgba(232, 220, 194, 0.72);
   font-size: var(--type-body);
 }
 
-.app-shell--gameplay-hud .topbar {
-  margin-bottom: 0;
-}
 
 .gameplay-brand {
   min-height: 50px;

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -1036,11 +1036,11 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
 /* Market slots styled identically to gameplay-hud hand slots: dark ticket card
    with brass color stripe on the left edge, count and label centered. */
 /* Right-col market slot uses the unified hand-slot styling defined below.
-   Only layout-specific tweaks here. */
+   Sized identical to hand slots (72px tall, same padding and fonts). */
 .app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot {
-  min-height: 0;
-  height: 100%;
-  padding: 8px 6px 8px 16px;
+  min-height: 72px;
+  height: 72px;
+  padding: 8px 6px;
   display: grid;
   place-items: center;
   gap: 4px;
@@ -1048,6 +1048,17 @@ body:has(.app-shell--gameplay-hud) .modal-shell .modal-shell__card .system-butto
   position: relative;
   text-align: center;
   cursor: pointer;
+}
+
+.app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot__count {
+  font-size: var(--type-lg);
+  font-weight: 900;
+}
+
+.app-shell--gameplay-hud .right-col .supply-dock--board .market-color-slot__label {
+  font-size: var(--type-xs);
+  font-weight: 700;
+  letter-spacing: 0.06em;
 }
 
 .app-shell--gameplay-hud .right-col .supply-dock--board .section-header {
@@ -3457,13 +3468,15 @@ border-color: rgba(232, 220, 194, 0.72);
   min-width: 0 !important;
 }
 
-/* Market inner grid: 2 columns × 3 rows (2 + 2 + 1). 5th card centered alone in row 3. */
+/* Market inner grid: 2 columns × 3 rows (2 + 2 + 1). 5th card centered alone in row 3.
+   Rows are auto so each card stays at its natural 72px hand-slot height. */
 .app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market {
   display: grid !important;
   grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
-  grid-template-rows: repeat(3, 1fr) !important;
+  grid-template-rows: repeat(3, auto) !important;
   gap: 6px;
   min-height: 0;
+  align-content: start;
 }
 
 .app-shell--gameplay-hud .right-col .supply-dock--board .supply-dock__market > :nth-child(1) {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -164,7 +164,27 @@
   letter-spacing: 0;
 }
 
-.app-shell--gameplay-hud .private-hand-rail__slots,
+/* Hand rail: 1x9 single-row strip showing all 8 colors + locomotive */
+.app-shell--gameplay-hud .private-hand-rail__slots {
+  grid-template-columns: repeat(9, minmax(0, 1fr));
+  gap: 4px;
+}
+
+/* Compact hand slots in the 1x9 strip — smaller than market slots */
+.app-shell--gameplay-hud .private-hand-rail .hand-color-slot {
+  min-height: 60px;
+  height: 60px;
+  padding: 6px 4px;
+}
+
+.app-shell--gameplay-hud .private-hand-rail .hand-color-slot__count {
+  font-size: var(--type-sm);
+}
+
+.app-shell--gameplay-hud .private-hand-rail .hand-color-slot__label {
+  font-size: var(--type-3xs);
+}
+
 .app-shell--gameplay-hud .inspector-dock .supply-dock__market {
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 8px;
@@ -1781,12 +1801,6 @@
 
 .app-shell--gameplay-hud .inspector-dock .supply-dock--board .section-header {
   padding-inline: 0;
-}
-
-.app-shell--gameplay-hud .private-hand-rail__slots,
-.app-shell--gameplay-hud .inspector-dock .supply-dock__market {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 8px;
 }
 
 .app-shell--gameplay-hud .hand-color-slot,

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -943,6 +943,22 @@
   font-size: var(--type-xs);
 }
 
+/* Board map scales fluidly inside the gameplay HUD column;
+   override the base 780px min-width so it can shrink with the viewport. */
+.app-shell--gameplay-hud .board-map {
+  min-width: 0;
+  max-width: 100%;
+  height: 100%;
+  width: 100%;
+}
+
+.app-shell--gameplay-hud .board-stage__map {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 /* Floating build popup on the map */
 .floating-build-panel {
   position: absolute;

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -96,16 +96,8 @@
   text-transform: uppercase;
 }
 
-.app-shell--gameplay-hud .private-hand-rail,
-.app-shell--gameplay-hud .ticket-dock,
-.app-shell--gameplay-hud .inspector-dock,
-.app-shell--gameplay-hud .side-panel .player-roster,
-.app-shell--gameplay-hud .chat-panel-dock {
-  background:
-    radial-gradient(circle at top left, rgba(142, 169, 188, 0.12), transparent 34%),
-    linear-gradient(180deg, rgba(30, 42, 51, 0.88), rgba(9, 15, 20, 0.9));
-  border-color: rgba(var(--hud-brass-light-rgb), 0.18);
-}
+/* Panel base styling (gradient + border + shadow) is defined later
+   in the unified rule that covers all dark panels. */
 
 /* Roster + chat heights are both bound to --roster-height so they always match.
    4 seat tiles × 40px + 3 gaps × 4px + panel padding (16px) ≈ 188px. */
@@ -901,16 +893,12 @@
 }
 
 /* Right-column SupplyDock layout: vertical stack with market as 2×3 grid */
+/* Layout-only — visual treatment (gradient/border/shadow) comes from the unified panel rule */
 .app-shell--gameplay-hud .right-col .supply-dock--board {
   display: flex;
   flex-direction: column;
   gap: var(--space-stack-sm, 8px);
   padding: var(--space-stack-sm) var(--space-stack-md);
-  border-radius: var(--radius-panel);
-  background:
-    radial-gradient(circle at top left, rgba(142, 169, 188, 0.12), transparent 34%),
-    linear-gradient(180deg, rgba(30, 42, 51, 0.88), rgba(9, 15, 20, 0.9));
-  border: 1px solid rgba(var(--hud-brass-light-rgb), 0.18);
   height: 100%;
   min-height: 0;
   width: 100%;
@@ -1119,8 +1107,11 @@
 .app-shell--gameplay-hud .private-hand-rail,
 .app-shell--gameplay-hud .ticket-dock,
 .app-shell--gameplay-hud .inspector-dock,
-.app-shell--gameplay-hud .player-roster--top {
-  border-color: color-mix(in srgb, var(--hud-brass) 42%, rgba(0, 0, 0, 0.34));
+.app-shell--gameplay-hud .player-roster--top,
+.app-shell--gameplay-hud .side-panel .player-roster,
+.app-shell--gameplay-hud .chat-panel-dock,
+.app-shell--gameplay-hud .right-col .supply-dock--board {
+  border: 1px solid color-mix(in srgb, var(--hud-brass) 42%, rgba(0, 0, 0, 0.34));
   border-radius: var(--radius-sm);
   background:
     var(--hud-grain),
@@ -1135,7 +1126,10 @@
 .app-shell--gameplay-hud .private-hand-rail::before,
 .app-shell--gameplay-hud .ticket-dock::before,
 .app-shell--gameplay-hud .inspector-dock::before,
-.app-shell--gameplay-hud .player-roster--top::before {
+.app-shell--gameplay-hud .player-roster--top::before,
+.app-shell--gameplay-hud .side-panel .player-roster::before,
+.app-shell--gameplay-hud .chat-panel-dock::before,
+.app-shell--gameplay-hud .right-col .supply-dock--board::before {
   background:
     linear-gradient(135deg, rgba(232, 220, 194, 0.08), transparent 28%),
     radial-gradient(circle at 18% 0%, rgba(183, 155, 97, 0.12), transparent 30%);

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -156,33 +156,58 @@
   gap: var(--space-stack-xs, 4px);
 }
 
+/* Side-panel SeatTile: avatar | name+meta | stats (timer is hidden if no value) */
 .app-shell--gameplay-hud .side-panel .player-roster .player-strip {
-  min-height: 40px;
-  height: 40px;
+  height: 100%;
+  min-height: 0;
   padding: 4px 8px;
   grid-template-columns: 28px minmax(0, 1fr) auto;
-  gap: 6px 8px;
+  grid-template-rows: 1fr;
+  gap: 4px 8px;
+  align-items: center;
 }
 
-/* Tighter typography to fit 4 rows */
+/* Hide the empty timer slot so the stats column lands next to the info */
+.app-shell--gameplay-hud .side-panel .player-roster .player-roster__timer:empty {
+  display: none;
+}
+
+/* Info column: name above one-line meta */
+.app-shell--gameplay-hud .side-panel .player-roster .row-object__main {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1px;
+  min-width: 0;
+}
+
 .app-shell--gameplay-hud .side-panel .player-roster .row-object__title {
   font-size: var(--type-xs);
   font-weight: 800;
   line-height: 1.1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .app-shell--gameplay-hud .side-panel .player-roster .row-object__meta {
   font-size: var(--type-2xs);
   line-height: 1.1;
+  white-space: nowrap;
+}
+
+/* Stats column: single line, comma-separated style */
+.app-shell--gameplay-hud .side-panel .player-roster .row-object__stats {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0;
+  white-space: nowrap;
 }
 
 .app-shell--gameplay-hud .side-panel .player-roster .row-object__stat {
   font-size: var(--type-2xs);
   line-height: 1.1;
-}
-
-.app-shell--gameplay-hud .side-panel .player-roster .row-object__stats {
-  gap: 1px;
 }
 
 .app-shell--gameplay-hud .side-panel .player-roster .seat-avatar--tiny {

--- a/apps/web/src/styles/game.css
+++ b/apps/web/src/styles/game.css
@@ -1,7 +1,7 @@
 /* Gameplay HUD type/layout convergence pass. Keep map labels untouched. */
 .app-shell--gameplay-hud {
-  padding: 4px 14px var(--space-stack-sm);
-  gap: var(--space-stack-xs, 4px);
+  padding: 0 14px 8px;
+  gap: 4px;
   font-size: var(--type-body);
 }
 
@@ -12,8 +12,9 @@
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
   gap: 12px;
-  min-height: 32px;
+  min-height: 28px;
   margin: 0;
+  padding: 0;
   position: relative;
   z-index: var(--z-modal);
 }

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -77,10 +77,13 @@
   align-self: end;
 }
 
+/* Right column: 50/50 split — chat top half, market bottom half */
 .right-col {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: 1fr 1fr;
   gap: var(--space-stack-sm);
+  height: 100%;
+  min-height: 0;
 }
 
 .side-panel__draw-ticket {

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -44,6 +44,18 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-stack-sm);
+  min-width: 0;
+}
+
+/* Board panel fills the available height of map-col (viewport-driven) */
+.map-col > .board-stage {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* Hand strip is a fixed bottom row, no flex grow */
+.map-col > .private-hand-rail {
+  flex: 0 0 auto;
 }
 
 .right-col {

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -58,8 +58,7 @@
   min-height: 0;
 }
 
-/* map-col is the dominant vertical: board stage fills remaining space,
-   hand strip locks to the bottom. */
+/* map-col: map fills the top (1fr), hand strip locked at the bottom (auto). */
 .map-col {
   display: grid;
   grid-template-rows: minmax(0, 1fr) auto;
@@ -69,11 +68,13 @@
 }
 
 .map-col > .board-stage {
+  grid-row: 1;
   min-height: 0;
   overflow: hidden;
 }
 
 .map-col > .private-hand-rail {
+  grid-row: 2;
   align-self: end;
 }
 

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -17,7 +17,7 @@
   --game-rail: clamp(280px, 20vw, 320px);
   --game-left-rail: var(--game-rail);
   --game-right-rail: var(--game-rail);
-  --topbar-allowance: 36px;
+  --topbar-allowance: 30px;
   display: grid;
   grid-template-columns: var(--game-left-rail) minmax(0, 1fr);
   gap: var(--space-stack-md);

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -16,7 +16,7 @@
 .game-layout {
   --game-left-rail: clamp(260px, 19vw, 300px);
   --game-right-rail: clamp(288px, 22vw, 340px);
-  --topbar-allowance: 48px;
+  --topbar-allowance: 36px;
   display: grid;
   grid-template-columns: var(--game-left-rail) minmax(0, 1fr);
   gap: var(--space-stack-md);

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -11,14 +11,18 @@
 
 /* Game layout — 3-column visual structure via nested grids:
    .game-layout = left-rail | board-column
-   .board-column = map-col | right-col */
+   .board-column = map-col | right-col
+   Layout fills viewport minus topbar so the map column can use 100% to anchor hand strip. */
 .game-layout {
   --game-left-rail: clamp(260px, 19vw, 300px);
   --game-right-rail: clamp(288px, 22vw, 340px);
+  --topbar-allowance: 48px;
   display: grid;
   grid-template-columns: var(--game-left-rail) minmax(0, 1fr);
   gap: var(--space-stack-md);
   align-items: start;
+  height: calc(100vh - var(--topbar-allowance));
+  min-height: 0;
 }
 
 .side-panel {
@@ -37,25 +41,28 @@
   display: grid;
   grid-template-columns: minmax(0, 1fr) var(--game-right-rail);
   gap: var(--space-stack-md);
-  align-items: start;
-}
-
-.map-col {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-stack-sm);
-  min-width: 0;
-}
-
-/* Board panel fills the available height of map-col (viewport-driven) */
-.map-col > .board-stage {
-  flex: 1 1 auto;
+  align-items: stretch;
+  height: 100%;
   min-height: 0;
 }
 
-/* Hand strip is a fixed bottom row, no flex grow */
+/* map-col is the dominant vertical: board stage fills remaining space,
+   hand strip locks to the bottom. */
+.map-col {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+  gap: var(--space-stack-sm);
+  min-width: 0;
+  min-height: 0;
+}
+
+.map-col > .board-stage {
+  min-height: 0;
+  overflow: hidden;
+}
+
 .map-col > .private-hand-rail {
-  flex: 0 0 auto;
+  align-self: end;
 }
 
 .right-col {

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -11,10 +11,10 @@
 
 /* Game layout — 3-column visual structure via nested grids:
    .game-layout = left-rail | board-column
-   .board-column = board-stage | inspector-dock (right-rail) */
+   .board-column = map-col | right-col */
 .game-layout {
-  --game-left-rail: clamp(286px, 21vw, 312px);
-  --game-right-rail: clamp(324px, 24vw, 356px);
+  --game-left-rail: clamp(260px, 19vw, 300px);
+  --game-right-rail: clamp(288px, 22vw, 340px);
   display: grid;
   grid-template-columns: var(--game-left-rail) minmax(0, 1fr);
   gap: var(--space-stack-md);
@@ -22,22 +22,32 @@
 }
 
 .side-panel {
-  display: grid;
-  gap: var(--space-stack-md);
-  align-content: start;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-stack-sm);
 }
 
 .board-column {
   display: grid;
   grid-template-columns: minmax(0, 1fr) var(--game-right-rail);
-  grid-template-rows: minmax(0, 1fr);
   gap: var(--space-stack-md);
-  align-content: start;
+  align-items: start;
 }
 
-.side-panel__private-stack {
-  display: grid;
+.map-col {
+  display: flex;
+  flex-direction: column;
   gap: var(--space-stack-sm);
+}
+
+.right-col {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-stack-sm);
+}
+
+.side-panel__draw-ticket {
+  width: 100%;
 }
 
 /* Setup flows */

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -25,6 +25,12 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-stack-sm);
+  align-self: start;
+}
+
+/* Each child in side-panel has fixed sizing — no flex-grow, no stretch */
+.side-panel > * {
+  flex: 0 0 auto;
 }
 
 .board-column {

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -14,7 +14,7 @@
    .board-column = map-col | right-col
    Height is dictated by flex parent so topbar shrinkage flows down. */
 .game-layout {
-  --game-rail: clamp(280px, 20vw, 320px);
+  --game-rail: clamp(233px, 17vw, 267px);
   --game-left-rail: var(--game-rail);
   --game-right-rail: var(--game-rail);
   display: grid;

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -26,16 +26,27 @@
   min-height: 0;
 }
 
+/* Left column: 50/50 split — roster top half, tickets+button bottom half */
 .side-panel {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: 1fr 1fr;
   gap: var(--space-stack-sm);
-  align-self: start;
+  height: 100%;
+  min-height: 0;
 }
 
-/* Each child in side-panel has fixed sizing — no flex-grow, no stretch */
-.side-panel > * {
-  flex: 0 0 auto;
+.side-panel__top,
+.side-panel__bottom {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-stack-xs, 4px);
+  min-height: 0;
+  overflow: hidden;
+}
+
+.side-panel__bottom {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
 }
 
 .board-column {

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -12,17 +12,15 @@
 /* Game layout — 3-column visual structure via nested grids:
    .game-layout = left-rail | board-column
    .board-column = map-col | right-col
-   Layout fills viewport minus topbar so the map column can use 100% to anchor hand strip. */
+   Height is dictated by flex parent so topbar shrinkage flows down. */
 .game-layout {
   --game-rail: clamp(280px, 20vw, 320px);
   --game-left-rail: var(--game-rail);
   --game-right-rail: var(--game-rail);
-  --topbar-allowance: 30px;
   display: grid;
   grid-template-columns: var(--game-left-rail) minmax(0, 1fr);
-  gap: var(--space-stack-md);
-  align-items: start;
-  height: calc(100vh - var(--topbar-allowance));
+  gap: var(--space-stack-sm);
+  align-items: stretch;
   min-height: 0;
 }
 
@@ -51,7 +49,7 @@
 .board-column {
   display: grid;
   grid-template-columns: minmax(0, 1fr) var(--game-right-rail);
-  gap: var(--space-stack-md);
+  gap: var(--space-stack-sm);
   align-items: stretch;
   height: 100%;
   min-height: 0;

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -14,8 +14,9 @@
    .board-column = map-col | right-col
    Layout fills viewport minus topbar so the map column can use 100% to anchor hand strip. */
 .game-layout {
-  --game-left-rail: clamp(260px, 19vw, 300px);
-  --game-right-rail: clamp(288px, 22vw, 340px);
+  --game-rail: clamp(280px, 20vw, 320px);
+  --game-left-rail: var(--game-rail);
+  --game-right-rail: var(--game-rail);
   --topbar-allowance: 36px;
   display: grid;
   grid-template-columns: var(--game-left-rail) minmax(0, 1fr);

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -26,10 +26,10 @@
   min-height: 0;
 }
 
-/* Left column: 50/50 split — roster top half, tickets+button bottom half */
+/* Left column: 40/60 split — roster (40% top), tickets + draw button (60% bottom) */
 .side-panel {
   display: grid;
-  grid-template-rows: 1fr 1fr;
+  grid-template-rows: 40fr 60fr;
   gap: var(--space-stack-sm);
   height: 100%;
   min-height: 0;
@@ -78,10 +78,10 @@
   align-self: end;
 }
 
-/* Right column: 50/50 split — chat top half, market bottom half */
+/* Right column: 40/60 split — chat top (40%), market bottom (60%) */
 .right-col {
   display: grid;
-  grid-template-rows: 1fr 1fr;
+  grid-template-rows: 40fr 60fr;
   gap: var(--space-stack-sm);
   height: 100%;
   min-height: 0;

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -77,10 +77,10 @@
   align-self: end;
 }
 
-/* Right column: 60/40 split — chat top (60%), market bottom (40%) */
+/* Right column: 50/50 split — chat top (50%), market bottom (50%) */
 .right-col {
   display: grid;
-  grid-template-rows: 60fr 40fr;
+  grid-template-rows: 50fr 50fr;
   gap: var(--space-stack-sm);
   height: 100%;
   min-height: 0;

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -39,14 +39,13 @@
 .side-panel__bottom {
   display: flex;
   flex-direction: column;
-  gap: var(--space-stack-xs, 4px);
   min-height: 0;
   overflow: hidden;
 }
 
-.side-panel__bottom {
-  display: grid;
-  grid-template-rows: minmax(0, 1fr) auto;
+.side-panel__bottom > .ticket-dock {
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .board-column {

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -77,10 +77,10 @@
   align-self: end;
 }
 
-/* Right column: 40/60 split — chat top (40%), market bottom (60%) */
+/* Right column: 60/40 split — chat top (60%), market bottom (40%) */
 .right-col {
   display: grid;
-  grid-template-rows: 40fr 60fr;
+  grid-template-rows: 60fr 40fr;
   gap: var(--space-stack-sm);
   height: 100%;
   min-height: 0;

--- a/apps/web/src/styles/layout.css
+++ b/apps/web/src/styles/layout.css
@@ -31,6 +31,7 @@
   gap: var(--space-stack-sm);
   height: 100%;
   min-height: 0;
+  align-self: stretch;
 }
 
 .side-panel__top,
@@ -51,6 +52,7 @@
   grid-template-columns: minmax(0, 1fr) var(--game-right-rail);
   gap: var(--space-stack-sm);
   align-items: stretch;
+  align-self: stretch;
   height: 100%;
   min-height: 0;
 }
@@ -82,6 +84,7 @@
   gap: var(--space-stack-sm);
   height: 100%;
   min-height: 0;
+  align-self: stretch;
 }
 
 .side-panel__draw-ticket {

--- a/apps/web/src/styles/onboarding.css
+++ b/apps/web/src/styles/onboarding.css
@@ -166,11 +166,20 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: 6px;
+  flex-wrap: wrap;
 }
 
 .tour-callout__forward {
   display: flex;
   align-items: center;
   gap: 6px;
+  flex-shrink: 0;
+}
+
+/* Keep tour buttons compact so they fit within the 320px callout width */
+.tour-callout .system-button {
+  min-width: 0;
+  padding-inline: var(--space-stack-md, 16px);
+  font-size: var(--type-xs);
 }

--- a/apps/web/src/styles/setup.css
+++ b/apps/web/src/styles/setup.css
@@ -1205,19 +1205,8 @@
   gap: 10px;
 }
 
-@media (max-width: 1200px) {
-  .app-shell--gameplay-hud .game-layout {
-    grid-template-columns: minmax(240px, 260px) minmax(0, 1fr);
-  }
-
-  .app-shell--gameplay-hud {
-    --game-right-rail: clamp(300px, 22vw, 340px);
-  }
-
-  .app-shell--gameplay-hud .board-column {
-    grid-template-columns: minmax(0, 1fr) minmax(260px, 280px);
-  }
-}
+/* Rail widths come from layout.css .game-layout (single --game-rail token).
+   No responsive overrides needed — clamp() handles viewport scaling. */
 
 @media (max-width: 1120px) {
   .setup-board,

--- a/apps/web/src/styles/ui.css
+++ b/apps/web/src/styles/ui.css
@@ -3669,9 +3669,9 @@ h3 {
 }
 
 .game-over-layer {
-  position: fixed;
-  inset: max(22px, var(--space-page-y)) max(22px, var(--space-page-x));
-  z-index: 42;
+  position: fixed !important;
+  inset: max(22px, var(--space-page-y)) max(22px, var(--space-page-x)) !important;
+  z-index: 9500 !important;
   display: grid;
   grid-template-columns: minmax(260px, 0.34fr) minmax(0, 1fr);
   gap: 20px;

--- a/apps/web/src/styles/ui.css
+++ b/apps/web/src/styles/ui.css
@@ -3051,7 +3051,7 @@ h3 {
 .modal-shell {
   position: fixed;
   inset: 0;
-  z-index: var(--z-modal);
+  z-index: 250;
   display: grid;
   place-items: center;
   padding: 24px;

--- a/apps/web/src/styles/ui.css
+++ b/apps/web/src/styles/ui.css
@@ -3626,6 +3626,7 @@ h3 {
 .notification-pipe__item {
   justify-self: center;
   max-width: 100%;
+  pointer-events: auto;
   padding: 10px 16px;
   border: 1px solid rgba(221, 199, 159, 0.28);
   border-radius: 999px;

--- a/apps/web/src/styles/ui.css
+++ b/apps/web/src/styles/ui.css
@@ -3049,14 +3049,23 @@ h3 {
 
 .overlay,
 .modal-shell {
-  position: fixed;
-  inset: 0;
-  z-index: 250;
+  position: fixed !important;
+  top: 0 !important;
+  left: 0 !important;
+  right: 0 !important;
+  bottom: 0 !important;
+  width: 100vw !important;
+  height: 100vh !important;
+  z-index: 9999 !important;
   display: grid;
   place-items: center;
   padding: 24px;
-  background: rgba(57, 42, 27, 0.52);
+  background: rgba(15, 11, 6, 0.72);
   animation: shell-fade-in var(--duration-slow) var(--easing-standard);
+}
+
+.modal-shell > * {
+  pointer-events: auto;
 }
 
 .overlay--tutorial,


### PR DESCRIPTION
## Summary

Major rebuild of the local + online gameplay screen. Replaces the previous inspector-tabs layout with a 5-panel HUD (roster, ticket dock, chat, market, hand strip) wrapped around the map. Build options now appear as a floating popup anchored to the clicked route/city. Notifications, modals, and ticket picker overlays no longer affect underlying layout.

## What changed

**Layout (local + online)**
- Topbar collapsed to a 24px row hugging the viewport edge; turn indicator + timer centered, icon-only ?/★/✕ buttons on the right with hover tooltips
- 3-column grid: equal-width left and right rails (single `--game-rail` token), center column has the map and hand strip
- Left column 50/50: player roster (top, all 4 seats) + ticket dock + draw button (bottom)
- Right column 50/50: chat panel + 2×3 market grid
- All five HUD panels use a unified dark-brass treatment

**Build popup**
- New `FloatingBuildPanel` anchored to mouse click position (clamps to viewport)
- Replaces the old InspectorDock build tab — clicking a new route/city closes the previous popup

**Notifications**
- Online + local both notify on draw / claim / station actions only (skip turn changes)
- Consecutive draws within a turn batch into one notification ("Player 1 drew emerald, ivory.")
- Unlimited queue, 2s display per item
- Notification pipe forced to viewport with high z-index, no layout impact

**Overlays**
- Notifications, leave-room modal, handoff modal, ticket picker, game-over scoreboard all float without affecting layout
- Game-over board: high-contrast text on dark surface, single-column breakdown
- Ticket picker covers only the right column

**Misc**
- Local play now has a working chat input (messages tagged with active player name)
- One-line chat message format ("Name: text")
- Custom thin scrollbar on chat
- Live turn timer added to local play
- Hand cards get larger count/label fonts

## Test plan
- [ ] Local: setup → lobby → start game with bots
- [ ] Click a route, build popup appears near click; X closes it; clicking a new route swaps the popup
- [ ] Draw cards (3 in a turn) → one combined notification
- [ ] Open chat, send a message, scroll past several messages
- [ ] Bot finishes turn → handoff modal floats; "I'm done" returns control
- [ ] Open leave-room confirm; click cancel; map state unaffected
- [ ] End the game → game-over scoreboard floats with readable buttons
- [ ] Online: create room → start game → verify same flows + chat between seats works

🤖 Generated with [Claude Code](https://claude.com/claude-code)